### PR TITLE
feat: Simplify serde deserializer

### DIFF
--- a/crates/smart-config-derive/src/describe.rs
+++ b/crates/smart-config-derive/src/describe.rs
@@ -86,7 +86,7 @@ impl ConfigField {
                 help: #help,
                 ty: #meta_mod::RustType::of::<#ty>(#ty_in_code),
                 expecting: const { #cr::de::extract_expected_types::<#ty, _>(&#deserializer) },
-                deserializer: const { &#cr::de::DeserializerWrapper::<#ty, _>::new(#deserializer) },
+                deserializer: const { &#cr::de::Erased::<#ty, _>::new(#deserializer) },
                 default_value: #default_value,
             }
         }}

--- a/crates/smart-config-derive/src/describe.rs
+++ b/crates/smart-config-derive/src/describe.rs
@@ -35,7 +35,7 @@ impl ConfigField {
             quote!(#with)
         } else {
             let ty = &self.ty;
-            quote_spanned!(ty.span()=> <#ty as #cr::de::WellKnown>::DE)
+            quote_spanned!(ty.span()=> ())
         };
         let default_fn = self.default_fn();
 
@@ -85,6 +85,7 @@ impl ConfigField {
                 aliases: &[#(#aliases,)*],
                 help: #help,
                 ty: #meta_mod::RustType::of::<#ty>(#ty_in_code),
+                expecting: const { #cr::de::extract_expected_types::<#ty, _>(&#deserializer) },
                 deserializer: const { &#cr::de::DeserializerWrapper::<#ty, _>::new(#deserializer) },
                 default_value: #default_value,
             }

--- a/crates/smart-config-derive/src/describe.rs
+++ b/crates/smart-config-derive/src/describe.rs
@@ -103,7 +103,7 @@ impl ConfigField {
         quote_spanned! {self.name.span()=>
             #cr::metadata::NestedConfigMetadata {
                 name: #config_name,
-                meta: <#ty as #cr::DescribeConfig>::describe_config(),
+                meta: &<#ty as #cr::DescribeConfig>::DESCRIPTION,
             }
         }
     }
@@ -147,15 +147,12 @@ impl ConfigContainer {
 
         quote! {
             impl #cr::DescribeConfig for #name {
-                fn describe_config() -> &'static #meta_mod::ConfigMetadata {
-                    static METADATA_CELL: #cr::Lazy<#meta_mod::ConfigMetadata> = #cr::Lazy::new(|| #meta_mod::ConfigMetadata {
-                        ty: #meta_mod::RustType::of::<#name>(#name_str),
-                        help: #help,
-                        params: ::std::boxed::Box::new([#(#params,)*]),
-                        nested_configs: ::std::boxed::Box::new([#(#nested_configs,)*]),
-                    });
-                    &METADATA_CELL
-                }
+                const DESCRIPTION: #meta_mod::ConfigMetadata = #meta_mod::ConfigMetadata {
+                    ty: #meta_mod::RustType::of::<#name>(#name_str),
+                    help: #help,
+                    params: &[#(#params,)*],
+                    nested_configs: &[#(#nested_configs,)*],
+                };
             }
         }
     }

--- a/crates/smart-config/README.md
+++ b/crates/smart-config/README.md
@@ -83,7 +83,7 @@ pub struct TestConfig {
     
     // For custom types, you can specify a custom deserializer. The deserializer below
     // expects a string and works for all types implementing `serde::Deserialize`.
-    #[config(with = Serde![BasicTypes::STRING])]
+    #[config(with = Serde![str])]
     #[config(default_t = CustomEnum::First)]
     pub custom: CustomEnum,
     

--- a/crates/smart-config/README.md
+++ b/crates/smart-config/README.md
@@ -51,7 +51,9 @@ smart-config = "0.1.0"
 ```rust
 use std::{collections::{HashMap, HashSet}, path::PathBuf, time::Duration};
 use serde::Deserialize;
-use smart_config::{de::Optional, metadata::*, ByteSize, DescribeConfig, DeserializeConfig};
+use smart_config::{
+    de::Optional, metadata::*, ByteSize, DescribeConfig, DeserializeConfig, Serde,
+};
 
 #[derive(Debug, Deserialize)]
 enum CustomEnum {
@@ -81,7 +83,7 @@ pub struct TestConfig {
     
     // For custom types, you can specify a custom deserializer. The deserializer below
     // expects a string and works for all types implementing `serde::Deserialize`.
-    #[config(with = BasicType::String)]
+    #[config(with = Serde![BasicTypes::STRING])]
     #[config(default_t = CustomEnum::First)]
     pub custom: CustomEnum,
     

--- a/crates/smart-config/README.md
+++ b/crates/smart-config/README.md
@@ -52,7 +52,7 @@ smart-config = "0.1.0"
 use std::{collections::{HashMap, HashSet}, path::PathBuf, time::Duration};
 use serde::Deserialize;
 use smart_config::{
-    de::Optional, metadata::*, ByteSize, DescribeConfig, DeserializeConfig, Serde,
+    de::{Optional, Serde}, metadata::*, ByteSize, DescribeConfig, DeserializeConfig,
 };
 
 #[derive(Debug, Deserialize)]

--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -1,12 +1,12 @@
 //! `serde`-compatible deserializer based on a value with origin.
 
-use std::{iter::empty, sync::Arc};
+use std::sync::Arc;
 
 use serde::{
     de::{
         self,
         value::{MapDeserializer, SeqDeserializer},
-        DeserializeOwned, DeserializeSeed, Error as DeError, IntoDeserializer,
+        DeserializeSeed, Error as DeError, IntoDeserializer,
     },
     Deserialize, Deserializer,
 };
@@ -43,25 +43,6 @@ macro_rules! parse_int_value {
             result.map_err(|err| err.set_origin_if_unset(&self.value.origin))
         }
         )*
-    }
-}
-
-pub(super) fn deserialize_string_as_array<T: DeserializeOwned>(
-    options: &DeserializerOptions,
-    s: &str,
-    pat: &str,
-    origin: &Arc<ValueOrigin>,
-) -> Result<T, ErrorWithOrigin> {
-    if s.is_empty() {
-        T::deserialize(SeqDeserializer::new(empty::<ValueDeserializer>()))
-    } else {
-        let items = s.split(pat).map(|item| WithOrigin {
-            inner: Value::String(item.to_owned()),
-            origin: origin.clone(), // TODO: better origin
-        });
-        let items: Vec<_> = items.collect();
-        let items = items.iter().map(|val| ValueDeserializer::new(val, options));
-        T::deserialize(SeqDeserializer::new(items))
     }
 }
 

--- a/crates/smart-config/src/de/macros.rs
+++ b/crates/smart-config/src/de/macros.rs
@@ -1,0 +1,81 @@
+/// Constructor of [`Serde`](struct@crate::de::Serde) types / instances.
+///
+/// The macro accepts a comma-separated list of expected basic types from the following set: `bool`, `int`,
+/// `float`, `str`, `array`, `object`. As a shortcut, `Serde![*]` signals to accept any input.
+///
+/// # Examples
+///
+/// ```
+/// # use serde::{Deserialize, Deserializer};
+/// # use smart_config::{de::Serde, DescribeConfig, DeserializeConfig};
+/// struct ComplexType {
+///     // ...
+/// }
+///
+/// impl<'de> Deserialize<'de> for ComplexType {
+///     // Complex deserialization logic...
+/// # fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+/// #     unreachable!()
+/// # }
+/// }
+///
+/// #[derive(DescribeConfig, DeserializeConfig)]
+/// struct TestConfig {
+///     /// Will try to deserialize any integer, string or object delegating
+///     /// to the `Deserialize` impl. Will error on other inputs (e.g., arrays).
+///     #[config(with = Serde![int, str, object])]
+///     complex_param: ComplexType,
+///     #[config(with = Serde![*])]
+///     anything: serde_json::Value,
+/// }
+/// ```
+#[macro_export]
+#[allow(non_snake_case)]
+macro_rules! Serde {
+    (@expand bool $($tail:tt)+) => {
+        $crate::metadata::BasicTypes::BOOL.or($crate::Serde!(@expand $($tail)+))
+    };
+    (@expand int $($tail:tt)+) => {
+        $crate::metadata::BasicTypes::INTEGER.or($crate::Serde!(@expand $($tail)+))
+    };
+    (@expand float $($tail:tt)+) => {
+        $crate::metadata::BasicTypes::FLOAT.or($crate::Serde!(@expand $($tail)+))
+    };
+    (@expand str $($tail:tt)+) => {
+        $crate::metadata::BasicTypes::STRING.or($crate::Serde!(@expand $($tail)+))
+    };
+    (@expand array $($tail:tt)+) => {
+        $crate::metadata::BasicTypes::ARRAY.or($crate::Serde!(@expand $($tail)+))
+    };
+    (@expand object $($tail:tt)+) => {
+        $crate::metadata::BasicTypes::OBJECT.or($crate::Serde!(@expand $($tail)+))
+    };
+
+    (@expand bool) => {
+        $crate::metadata::BasicTypes::BOOL
+    };
+    (@expand int) => {
+        $crate::metadata::BasicTypes::INTEGER
+    };
+    (@expand float) => {
+        $crate::metadata::BasicTypes::FLOAT
+    };
+    (@expand str) => {
+        $crate::metadata::BasicTypes::STRING
+    };
+    (@expand array) => {
+        $crate::metadata::BasicTypes::ARRAY
+    };
+    (@expand object) => {
+        $crate::metadata::BasicTypes::OBJECT
+    };
+
+    (*) => {
+        $crate::de::Serde::<{ $crate::metadata::BasicTypes::ANY.raw() }>
+    };
+    ($($expecting:tt),+ $(,)?) => {
+        $crate::de::Serde::<{ $crate::metadata::BasicTypes::raw($crate::Serde!(@expand $($expecting)+)) }>
+    };
+}
+
+pub use Serde;

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Universal deserializers
 //!
-//! [`BasicType`](crate::metadata::BasicType) and [`SchemaType`](crate::metadata::SchemaType) can deserialize
+//! [`BasicType`](crate::metadata::BasicType) and [`SchemaType`](crate::metadata::TypeQualifiers) can deserialize
 //! any param implementing [`serde::Deserialize`]. An important caveat is that these deserializers require
 //! the input `Value` to be present; otherwise, they'll fail with a "missing value" error. As such,
 //! for [`Option`]al types, it's necessary to wrap a deserializer in the [`Optional`] decorator.
@@ -40,13 +40,13 @@ use self::deserializer::ValueDeserializer;
 pub use self::{
     deserializer::DeserializerOptions,
     param::{
-        Delimited, DeserializeParam, DeserializerWrapper, ObjectSafeDeserializer, Optional,
-        OrString, TagDeserializer, WellKnown, WithDefault,
+        Delimited, DeserializeParam, DeserializerWrapper, ExpectParam, ObjectSafeDeserializer,
+        Optional, OrString, Serde, TagDeserializer, WithDefault,
     },
 };
 use crate::{
     error::{ErrorWithOrigin, LocationInConfig},
-    metadata::{ConfigMetadata, ParamMetadata},
+    metadata::{BasicTypes, ConfigMetadata, ParamMetadata},
     value::{Pointer, ValueOrigin, WithOrigin},
     DescribeConfig, ParseError, ParseErrors,
 };
@@ -55,6 +55,11 @@ mod deserializer;
 mod param;
 #[cfg(test)]
 mod tests;
+
+#[doc(hidden)] // used by proc macros
+pub const fn extract_expected_types<T, De: ExpectParam<T>>(_: &De) -> BasicTypes {
+    <De as ExpectParam<T>>::EXPECTING
+}
 
 /// Context for deserializing a configuration.
 #[derive(Debug)]

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -15,9 +15,8 @@
 //!
 //! # Deserializers
 //!
-//! The default deserializer is extracted from the param type with the help of [`WellKnown`] trait.
-//! If you have a custom type defined locally which you want to use in configs, the easiest solution
-//! would be to implement `WellKnown` for it.
+//! The default deserializer is `()`. If you have a custom type defined locally which you want to use in configs, the easiest solution
+//! would be to implement [`ExpectParam`]`<YourType> for ()`.
 //! Alternatively, it's possible to specify a custom deserializer using `#[config(with = _)]` attribute.
 //!
 //! ## Universal deserializers
@@ -40,8 +39,8 @@ use self::deserializer::ValueDeserializer;
 pub use self::{
     deserializer::DeserializerOptions,
     param::{
-        Delimited, DeserializeParam, DeserializerWrapper, ExpectParam, ObjectSafeDeserializer,
-        Optional, OrString, Serde, TagDeserializer, WithDefault,
+        Delimited, DeserializeParam, Erased, ErasedDeserializer, ExpectParam, Optional, OrString,
+        Serde, TagDeserializer, WithDefault,
     },
 };
 use crate::{

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -41,7 +41,7 @@ pub use self::{
     deserializer::DeserializerOptions,
     param::{
         Delimited, DeserializeParam, DeserializerWrapper, ObjectSafeDeserializer, Optional,
-        TagDeserializer, WellKnown, WithDefault,
+        OrString, TagDeserializer, WellKnown, WithDefault,
     },
 };
 use crate::{

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -40,8 +40,8 @@ use self::deserializer::ValueDeserializer;
 pub use self::{
     deserializer::DeserializerOptions,
     param::{
-        DeserializeParam, DeserializerWrapper, ObjectSafeDeserializer, Optional, TagDeserializer,
-        WellKnown, WithDefault,
+        Csv, DeserializeParam, DeserializerWrapper, ObjectSafeDeserializer, Optional,
+        TagDeserializer, WellKnown, WithDefault,
     },
 };
 use crate::{

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -21,7 +21,7 @@
 //!
 //! ## Universal deserializers
 //!
-//! [`BasicType`](crate::metadata::BasicType) and [`SchemaType`](crate::metadata::TypeQualifiers) can deserialize
+//! [`Serde`](struct@Serde) (usually instantiated via [the eponymous macro](macro@Serde)) can deserialize
 //! any param implementing [`serde::Deserialize`]. An important caveat is that these deserializers require
 //! the input `Value` to be present; otherwise, they'll fail with a "missing value" error. As such,
 //! for [`Option`]al types, it's necessary to wrap a deserializer in the [`Optional`] decorator.
@@ -36,12 +36,12 @@
 use serde::de::Error as DeError;
 
 use self::deserializer::ValueDeserializer;
+#[doc(hidden)]
+pub use self::param::{Erased, ErasedDeserializer, TagDeserializer};
 pub use self::{
     deserializer::DeserializerOptions,
-    param::{
-        Delimited, DeserializeParam, Erased, ErasedDeserializer, ExpectParam, Optional, OrString,
-        Serde, TagDeserializer, WithDefault,
-    },
+    macros::Serde,
+    param::{Delimited, DeserializeParam, ExpectParam, Optional, OrString, Serde, WithDefault},
 };
 use crate::{
     error::{ErrorWithOrigin, LocationInConfig},
@@ -51,6 +51,7 @@ use crate::{
 };
 
 mod deserializer;
+mod macros;
 mod param;
 #[cfg(test)]
 mod tests;

--- a/crates/smart-config/src/de/param.rs
+++ b/crates/smart-config/src/de/param.rs
@@ -61,7 +61,7 @@ pub trait DeserializeParam<T>: fmt::Debug + Send + Sync + 'static {
     ) -> Result<T, ErrorWithOrigin>;
 }
 
-/// Deserializer powered by `serde`. Usually created with the help of [`Serde!`](macro@Serde) macro;
+/// Deserializer powered by `serde`. Usually created with the help of [`Serde!`](crate::Serde!) macro;
 /// see its docs for the examples of usage.
 pub struct Serde<const EXPECTING: u8>;
 
@@ -72,66 +72,6 @@ impl<const EXPECTING: u8> fmt::Debug for Serde<EXPECTING> {
             .field(&BasicTypes::from_raw(EXPECTING))
             .finish()
     }
-}
-
-/// Constructor of [`Serde`](struct@Serde) types / instances.
-///
-/// The macro accepts a comma-separated list of expected basic types from the following set: `bool`, `int`,
-/// `float`, `str`, `array`, `object`.
-///
-/// # Examples
-///
-/// ```
-/// # use smart_config::{Serde, de::ExpectParam, metadata::BasicTypes};
-/// type MySerde = Serde![int, str, object];
-/// ```
-#[allow(non_snake_case)]
-#[macro_export]
-macro_rules! Serde {
-    (@expand bool $($tail:tt)+) => {
-        $crate::metadata::BasicTypes::BOOL.or($crate::Serde!(@expand $($tail)+))
-    };
-    (@expand int $($tail:tt)+) => {
-        $crate::metadata::BasicTypes::INTEGER.or($crate::Serde!(@expand $($tail)+))
-    };
-    (@expand float $($tail:tt)+) => {
-        $crate::metadata::BasicTypes::FLOAT.or($crate::Serde!(@expand $($tail)+))
-    };
-    (@expand str $($tail:tt)+) => {
-        $crate::metadata::BasicTypes::STRING.or($crate::Serde!(@expand $($tail)+))
-    };
-    (@expand array $($tail:tt)+) => {
-        $crate::metadata::BasicTypes::ARRAY.or($crate::Serde!(@expand $($tail)+))
-    };
-    (@expand object $($tail:tt)+) => {
-        $crate::metadata::BasicTypes::OBJECT.or($crate::Serde!(@expand $($tail)+))
-    };
-
-    (@expand bool) => {
-        $crate::metadata::BasicTypes::BOOL
-    };
-    (@expand int) => {
-        $crate::metadata::BasicTypes::INTEGER
-    };
-    (@expand float) => {
-        $crate::metadata::BasicTypes::FLOAT
-    };
-    (@expand str) => {
-        $crate::metadata::BasicTypes::STRING
-    };
-    (@expand array) => {
-        $crate::metadata::BasicTypes::ARRAY
-    };
-    (@expand object) => {
-        $crate::metadata::BasicTypes::OBJECT
-    };
-    (@expand any) => {
-        $crate::metadata::BasicTypes::ANY
-    };
-
-    ($($expecting:tt),+ $(,)?) => {
-        $crate::de::Serde::<{ $crate::metadata::BasicTypes::raw($crate::Serde!(@expand $($expecting)+)) }>
-    };
 }
 
 impl<T: DeserializeOwned, const EXPECTING: u8> ExpectParam<T> for Serde<EXPECTING> {
@@ -684,7 +624,7 @@ where
 /// # use std::{collections::HashSet, str::FromStr};
 /// use anyhow::Context as _;
 /// # use serde::Deserialize;
-/// use smart_config::{de, testing, DescribeConfig, DeserializeConfig, Serde};
+/// use smart_config::{de, testing, DescribeConfig, DeserializeConfig};
 ///
 /// #[derive(Deserialize)]
 /// #[serde(transparent)]
@@ -703,7 +643,7 @@ where
 ///
 /// #[derive(DescribeConfig, DeserializeConfig)]
 /// struct TestConfig {
-///     #[config(with = de::OrString(Serde![array]))]
+///     #[config(with = de::OrString(de::Serde![array]))]
 ///     value: MySet,
 /// }
 ///

--- a/crates/smart-config/src/de/param.rs
+++ b/crates/smart-config/src/de/param.rs
@@ -86,7 +86,7 @@ pub trait WellKnownArray: WellKnown {}
 /// This deserializer assumes that the value is required. Hence, optional params should be wrapped in [`Optional`] to work correctly.
 impl<T: DeserializeOwned> DeserializeParam<T> for SchemaType {
     fn expecting(&self) -> SchemaType {
-        *self
+        self.clone()
     }
 
     fn deserialize_param(
@@ -510,7 +510,7 @@ pub struct Delimited(pub &'static str);
 
 impl<T: WellKnownArray> DeserializeParam<T> for Delimited {
     fn expecting(&self) -> SchemaType {
-        SchemaType::ANY.with_qualifier("array or delimited string")
+        SchemaType::ANY.with_dyn_qualifier(format!("array or {:?}-delimited string", self.0))
     }
 
     fn deserialize_param(

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -356,6 +356,7 @@ fn parsing_complex_types() {
             short_dur: Duration::from_millis(100),
             path: "./test".into(),
             memory_size_mb: Some(ByteSize::new(128, SizeUnit::MiB)),
+            paths: vec![],
         }
     );
 
@@ -365,6 +366,7 @@ fn parsing_complex_types() {
         "assumed": 24,
         "short_dur": 200,
         "path": "/mnt",
+        "paths": "/usr/bin:/usr/local/bin",
         "memory_size_mb": 64,
     );
     let config: ConfigWithComplexTypes = test_deserialize(json.inner()).unwrap();
@@ -378,6 +380,7 @@ fn parsing_complex_types() {
             short_dur: Duration::from_millis(200),
             path: "/mnt".into(),
             memory_size_mb: Some(ByteSize::new(64, SizeUnit::MiB)),
+            paths: vec!["/usr/bin".into(), "/usr/local/bin".into()],
         }
     );
 
@@ -388,6 +391,7 @@ fn parsing_complex_types() {
         "assumed": (),
         "short_dur": 1000,
         "memory_size_mb": (),
+        "paths": ["/usr/bin", "/mnt"],
     );
     let config: ConfigWithComplexTypes = test_deserialize(json.inner()).unwrap();
     assert_eq!(
@@ -400,6 +404,7 @@ fn parsing_complex_types() {
             short_dur: Duration::from_secs(1),
             path: "./test".into(),
             memory_size_mb: None,
+            paths: vec!["/usr/bin".into(), "/mnt".into()],
         }
     );
 }

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -149,7 +149,7 @@ fn parsing_enum_config_missing_tag() {
     let inner = err.inner().to_string();
     assert!(inner.contains("missing field"), "{inner}");
     assert_eq!(err.path(), "type");
-    assert_eq!(err.config().ty, EnumConfig::describe_config().ty);
+    assert_eq!(err.config().ty, EnumConfig::DESCRIPTION.ty);
     assert_eq!(err.param().unwrap().name, "type");
 }
 
@@ -163,7 +163,7 @@ fn parsing_enum_config_unknown_tag() {
     let inner = err.inner().to_string();
     assert!(inner.contains("unknown variant"), "{inner}");
     assert_eq!(err.path(), "type");
-    assert_eq!(err.config().ty, EnumConfig::describe_config().ty);
+    assert_eq!(err.config().ty, EnumConfig::DESCRIPTION.ty);
     assert_eq!(err.param().unwrap().name, "type");
 }
 
@@ -231,7 +231,7 @@ fn parsing_compound_config_missing_nested_value() {
     let inner = err.inner().to_string();
     assert!(inner.contains("missing field"), "{inner}");
     assert_eq!(err.path(), "nested.renamed");
-    assert_eq!(err.config().ty, NestedConfig::describe_config().ty);
+    assert_eq!(err.config().ty, NestedConfig::DESCRIPTION.ty);
     assert_eq!(err.param().unwrap().name, "renamed");
 }
 
@@ -309,7 +309,7 @@ fn type_mismatch_parsing_error() {
 
     assert!(err.inner().to_string().contains("invalid type"), "{err}");
     assert_eq!(extract_env_var_name(err.origin()), "other_int");
-    assert_eq!(err.config().ty, NestedConfig::describe_config().ty);
+    assert_eq!(err.config().ty, NestedConfig::DESCRIPTION.ty);
     assert_eq!(err.param().unwrap().name, "other_int");
 }
 
@@ -322,7 +322,7 @@ fn missing_parameter_parsing_error() {
     let err = errors.first();
     let inner = err.inner().to_string();
     assert!(inner.contains("missing field"), "{inner}");
-    assert_eq!(err.config().ty, NestedConfig::describe_config().ty);
+    assert_eq!(err.config().ty, NestedConfig::DESCRIPTION.ty);
     assert_eq!(err.param().unwrap().name, "renamed");
 }
 
@@ -335,7 +335,7 @@ fn missing_nested_config_parsing_error() {
     let inner = err.inner().to_string();
     assert!(inner.contains("missing field"), "{inner}");
     assert_eq!(err.path(), "nested.renamed");
-    assert_eq!(err.config().ty, NestedConfig::describe_config().ty);
+    assert_eq!(err.config().ty, NestedConfig::DESCRIPTION.ty);
     assert_eq!(err.param().unwrap().name, "renamed");
 }
 
@@ -418,7 +418,6 @@ fn parsing_complex_types() {
 fn error_parsing_array_from_string() {
     let json = config!("array": "4,what");
     let err = test_deserialize::<ConfigWithComplexTypes>(json.inner()).unwrap_err();
-    dbg!(&err);
     assert_eq!(err.len(), 1);
     let err = err.first();
     assert_eq!(err.path(), "array");

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -361,7 +361,7 @@ fn parsing_complex_types() {
     );
 
     let json = config!(
-        "array": [4, 5],
+        "array": "5,4",
         "choices": ["first", "second"],
         "assumed": 24,
         "short_dur": 200,
@@ -374,7 +374,7 @@ fn parsing_complex_types() {
         config,
         ConfigWithComplexTypes {
             float: 4.2,
-            array: [NonZeroUsize::new(4).unwrap(), NonZeroUsize::new(5).unwrap()],
+            array: [NonZeroUsize::new(5).unwrap(), NonZeroUsize::new(4).unwrap()],
             choices: Some(vec![SimpleEnum::First, SimpleEnum::Second]),
             assumed: Some(serde_json::json!(24)),
             short_dur: Duration::from_millis(200),

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -418,6 +418,7 @@ fn parsing_complex_types() {
 fn error_parsing_array_from_string() {
     let json = config!("array": "4,what");
     let err = test_deserialize::<ConfigWithComplexTypes>(json.inner()).unwrap_err();
+    dbg!(&err);
     assert_eq!(err.len(), 1);
     let err = err.first();
     assert_eq!(err.path(), "array");
@@ -489,7 +490,7 @@ fn parsing_complex_types_errors() {
     let err = errors.first();
     let inner = err.inner().to_string();
     assert!(
-        inner.contains("invalid type") && inner.contains("expected float"),
+        inner.contains("invalid type") && inner.contains("expected integer | float"),
         "{inner}"
     );
     assert_eq!(err.path(), "assumed");

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -141,7 +141,7 @@ pub mod value;
 /// Describes a configuration (i.e., a group of related parameters).
 pub trait DescribeConfig: 'static {
     /// Provides the config description.
-    fn describe_config() -> &'static ConfigMetadata;
+    const DESCRIPTION: ConfigMetadata;
 }
 
 #[cfg(doctest)]

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -85,8 +85,8 @@
 //! ```
 //! use std::collections::HashMap;
 //! use smart_config::{
-//!     de::{DeserializeParam, WellKnown},
-//!     metadata::BasicType, DescribeConfig, DeserializeConfig,
+//!     de::ExpectParam, metadata::BasicTypes,
+//!     DescribeConfig, DeserializeConfig,
 //! };
 //!
 //! #[derive(Debug, serde::Deserialize)]
@@ -95,10 +95,10 @@
 //!     Second,
 //! }
 //!
-//! impl WellKnown for CustomEnum {
+//! impl ExpectParam<CustomEnum> for () {
 //!     // signals that the type should be deserialized via `serde`
 //!     // and the expected input is a string
-//!     const DE: &'static dyn DeserializeParam<Self> = &BasicType::String;
+//!     const EXPECTING: BasicTypes = BasicTypes::STRING;
 //! }
 //!
 //! // Then, the type can be used in configs basically everywhere:

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{any, borrow::Cow, fmt};
 
-use crate::de::ObjectSafeDeserializer;
+use crate::de::ErasedDeserializer;
 
 #[cfg(test)]
 mod tests;
@@ -44,7 +44,7 @@ pub struct ParamMetadata {
     /// Basic type(s) expected by the param deserializer.
     pub expecting: BasicTypes,
     #[doc(hidden)] // implementation detail
-    pub deserializer: &'static dyn ObjectSafeDeserializer,
+    pub deserializer: &'static dyn ErasedDeserializer,
     #[doc(hidden)] // implementation detail
     pub default_value: Option<fn() -> Box<dyn fmt::Debug>>,
 }
@@ -94,7 +94,7 @@ impl RustType {
     }
 }
 
-/// One or more basic types in the JSON object model.
+/// Set of one or more basic types in the JSON object model.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BasicTypes(u8);
 
@@ -137,11 +137,13 @@ impl BasicTypes {
         self.0
     }
 
+    /// Returns a union of two sets of basic types.
     #[must_use]
     pub const fn or(self, rhs: Self) -> Self {
         Self(self.0 | rhs.0)
     }
 
+    /// Checks whether the `needle` is fully contained in this set.
     pub const fn contains(self, needle: Self) -> bool {
         self.0 & needle.0 == needle.0
     }

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -134,7 +134,7 @@ impl fmt::Display for BasicType {
 pub struct SchemaType {
     /// `None` means that arbitrary values are accepted.
     pub(crate) base: Option<BasicType>,
-    pub(crate) qualifier: Option<&'static str>,
+    pub(crate) qualifier: Option<&'static str>, // FIXME: Cow
     pub(crate) unit: Option<UnitOfMeasurement>,
 }
 

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -17,9 +17,9 @@ pub struct ConfigMetadata {
     /// Help regarding the config itself.
     pub help: &'static str,
     /// Parameters included in the config.
-    pub params: Box<[ParamMetadata]>,
+    pub params: &'static [ParamMetadata],
     /// Nested configs included in the config.
-    pub nested_configs: Box<[NestedConfigMetadata]>,
+    pub nested_configs: &'static [NestedConfigMetadata],
 }
 
 impl ConfigMetadata {
@@ -59,7 +59,7 @@ impl ParamMetadata {
 /// Representation of a Rust type.
 #[derive(Clone, Copy)]
 pub struct RustType {
-    id: any::TypeId,
+    id: fn() -> any::TypeId,
     name_in_code: &'static str,
 }
 
@@ -77,15 +77,15 @@ impl PartialEq for RustType {
 
 impl RustType {
     /// Creates a new type.
-    pub fn of<T: 'static>(name_in_code: &'static str) -> Self {
+    pub const fn of<T: 'static>(name_in_code: &'static str) -> Self {
         Self {
-            id: any::TypeId::of::<T>(),
+            id: any::TypeId::of::<T>,
             name_in_code,
         }
     }
 
     pub(crate) fn id(&self) -> any::TypeId {
-        self.id
+        (self.id)()
     }
 
     /// Returns the name of this type as specified in code.

--- a/crates/smart-config/src/metadata/tests.rs
+++ b/crates/smart-config/src/metadata/tests.rs
@@ -67,6 +67,10 @@ fn describing_complex_types() {
         .unwrap();
     let expecting = array_param.deserializer.expecting();
     assert_eq!(expecting.base, None);
+    assert_eq!(
+        expecting.qualifier().unwrap(),
+        "array or \",\"-delimited string"
+    );
 
     let assumed_param = metadata
         .params

--- a/crates/smart-config/src/metadata/tests.rs
+++ b/crates/smart-config/src/metadata/tests.rs
@@ -65,10 +65,8 @@ fn describing_complex_types() {
         .iter()
         .find(|param| param.name == "array")
         .unwrap();
-    assert_eq!(
-        array_param.deserializer.expecting().base,
-        Some(BasicType::Array)
-    );
+    let expecting = array_param.deserializer.expecting();
+    assert_eq!(expecting.base, None);
 
     let assumed_param = metadata
         .params

--- a/crates/smart-config/src/metadata/tests.rs
+++ b/crates/smart-config/src/metadata/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 
 #[test]
 fn describing_enum_config() {
-    let metadata: &ConfigMetadata = EnumConfig::describe_config();
+    let metadata = &EnumConfig::DESCRIPTION;
     assert_eq!(metadata.nested_configs.len(), 1);
     assert_eq!(metadata.nested_configs[0].name, "");
 
@@ -44,7 +44,7 @@ fn describing_enum_config() {
 
 #[test]
 fn describing_defaulting_enum_config() {
-    let metadata: &ConfigMetadata = DefaultingEnumConfig::describe_config();
+    let metadata = &DefaultingEnumConfig::DESCRIPTION;
     let tag_param = metadata
         .params
         .iter()
@@ -56,7 +56,7 @@ fn describing_defaulting_enum_config() {
 
 #[test]
 fn describing_complex_types() {
-    let metadata: &ConfigMetadata = ConfigWithComplexTypes::describe_config();
+    let metadata = &ConfigWithComplexTypes::DESCRIPTION;
     let array_param = metadata
         .params
         .iter()

--- a/crates/smart-config/src/metadata/tests.rs
+++ b/crates/smart-config/src/metadata/tests.rs
@@ -39,10 +39,7 @@ fn describing_enum_config() {
         .iter()
         .find(|param| param.name == "type")
         .unwrap();
-    assert_eq!(
-        tag_param.deserializer.expecting().base,
-        Some(BasicType::String)
-    );
+    assert_eq!(tag_param.expecting, BasicTypes::STRING);
 }
 
 #[test]
@@ -65,11 +62,17 @@ fn describing_complex_types() {
         .iter()
         .find(|param| param.name == "array")
         .unwrap();
-    let expecting = array_param.deserializer.expecting();
-    assert_eq!(expecting.base, None);
     assert_eq!(
-        expecting.qualifier().unwrap(),
-        "array or \",\"-delimited string"
+        array_param.expecting,
+        BasicTypes::ARRAY.or(BasicTypes::STRING)
+    );
+    assert_eq!(
+        array_param
+            .deserializer
+            .type_qualifiers()
+            .description
+            .unwrap(),
+        "using \",\" delimiter"
     );
 
     let assumed_param = metadata
@@ -77,27 +80,24 @@ fn describing_complex_types() {
         .iter()
         .find(|param| param.name == "assumed")
         .unwrap();
-    assert_eq!(
-        assumed_param.deserializer.expecting().base,
-        Some(BasicType::Float)
-    );
+    assert_eq!(assumed_param.expecting, BasicTypes::FLOAT);
 
     let path_param = metadata
         .params
         .iter()
         .find(|param| param.name == "path")
         .unwrap();
-    let expecting = path_param.deserializer.expecting();
-    assert_eq!(expecting.base, Some(BasicType::String));
-    assert_eq!(expecting.qualifier.unwrap(), "filesystem path");
+    assert_eq!(path_param.expecting, BasicTypes::STRING);
+    let qualifiers = path_param.deserializer.type_qualifiers();
+    assert_eq!(qualifiers.description.unwrap(), "filesystem path");
 
     let dur_param = metadata
         .params
         .iter()
         .find(|param| param.name == "short_dur")
         .unwrap();
-    let expecting = dur_param.deserializer.expecting();
-    assert_eq!(expecting.base, Some(BasicType::Integer));
-    assert_eq!(expecting.qualifier.unwrap(), "time duration");
-    assert_eq!(expecting.unit, Some(TimeUnit::Millis.into()));
+    assert_eq!(dur_param.expecting, BasicTypes::INTEGER);
+    let qualifiers = dur_param.deserializer.type_qualifiers();
+    assert_eq!(qualifiers.description.unwrap(), "time duration");
+    assert_eq!(qualifiers.unit, Some(TimeUnit::Millis.into()));
 }

--- a/crates/smart-config/src/schema.rs
+++ b/crates/smart-config/src/schema.rs
@@ -325,7 +325,7 @@ impl ConfigSchema {
             writeln!(writer, "{prefix}{prefix_sep}{alias}")?;
         }
 
-        let kind = param.deserializer.expecting();
+        let kind = param.expecting;
         let ty = format!("{kind} [Rust: {}]", param.ty.name_in_code());
         let default = if let Some(default) = param.default_value() {
             format!(", default: {default:?}")
@@ -347,7 +347,7 @@ impl ConfigSchema {
 mod tests {
     use super::*;
     use crate::{
-        metadata::BasicType, value::Value, ConfigRepository, DescribeConfig, DeserializeConfig,
+        metadata::BasicTypes, value::Value, ConfigRepository, DescribeConfig, DeserializeConfig,
         Environment,
     };
 
@@ -406,10 +406,7 @@ mod tests {
         assert_eq!(optional_metadata.aliases, [] as [&str; 0]);
         assert_eq!(optional_metadata.help, "Optional value.");
         assert_eq!(optional_metadata.ty.name_in_code(), "Option"); // FIXME: does `Option<u32>` get printed only for nightly Rust?
-        assert_eq!(
-            optional_metadata.deserializer.expecting().base,
-            Some(BasicType::Integer)
-        );
+        assert_eq!(optional_metadata.expecting, BasicTypes::INTEGER);
     }
 
     const EXPECTED_HELP: &str = r#"

--- a/crates/smart-config/src/source/json.rs
+++ b/crates/smart-config/src/source/json.rs
@@ -75,7 +75,7 @@ impl Json {
         debug_assert!(matches!(&self.inner.inner, Value::Object(_)));
     }
 
-    fn map_value(
+    pub(crate) fn map_value(
         value: serde_json::Value,
         file_origin: &Arc<ValueOrigin>,
         path: String,

--- a/crates/smart-config/src/source/json.rs
+++ b/crates/smart-config/src/source/json.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use super::{ConfigContents, ConfigSource};
-use crate::value::{Map, Pointer, Value, ValueOrigin, WithOrigin};
+use crate::value::{FileFormat, Map, Pointer, Value, ValueOrigin, WithOrigin};
 
 /// JSON-based configuration source.
 #[derive(Debug)]
 pub struct Json {
-    filename: Arc<str>,
+    origin: Arc<ValueOrigin>,
     inner: WithOrigin,
 }
 
@@ -18,9 +18,12 @@ impl Json {
 
     /// Creates a source with the specified name and contents.
     pub fn new(filename: &str, object: serde_json::Map<String, serde_json::Value>) -> Self {
-        let filename: Arc<str> = filename.into();
-        let inner = Self::map_value(serde_json::Value::Object(object), &filename, String::new());
-        Self { filename, inner }
+        let origin = Arc::new(ValueOrigin::File {
+            name: filename.to_owned(),
+            format: FileFormat::Json,
+        });
+        let inner = Self::map_value(serde_json::Value::Object(object), &origin, String::new());
+        Self { origin, inner }
     }
 
     /// Merges a value at the specified path into JSON.
@@ -39,12 +42,12 @@ impl Json {
             "Cannot overwrite root object"
         );
 
-        let value = Self::map_value(value, &self.filename, at.to_owned());
+        let value = Self::map_value(value, &self.origin, at.to_owned());
 
         let merge_point = if let Some((parent, last_segment)) = Pointer(at).split_last() {
             self.inner.ensure_object(parent, |path| {
-                Arc::new(ValueOrigin::Json {
-                    filename: self.filename.clone(),
+                Arc::new(ValueOrigin::Path {
+                    source: self.origin.clone(),
                     path: path.0.to_owned(),
                 })
             });
@@ -72,7 +75,11 @@ impl Json {
         debug_assert!(matches!(&self.inner.inner, Value::Object(_)));
     }
 
-    fn map_value(value: serde_json::Value, filename: &Arc<str>, path: String) -> WithOrigin {
+    fn map_value(
+        value: serde_json::Value,
+        file_origin: &Arc<ValueOrigin>,
+        path: String,
+    ) -> WithOrigin {
         let inner = match value {
             serde_json::Value::Bool(value) => Value::Bool(value),
             serde_json::Value::Number(value) => Value::Number(value),
@@ -84,7 +91,7 @@ impl Json {
                     .enumerate()
                     .map(|(i, value)| {
                         let child_path = Pointer(&path).join(&i.to_string());
-                        Self::map_value(value, filename, child_path)
+                        Self::map_value(value, file_origin, child_path)
                     })
                     .collect(),
             ),
@@ -92,7 +99,7 @@ impl Json {
                 values
                     .into_iter()
                     .map(|(key, value)| {
-                        let value = Self::map_value(value, filename, Pointer(&path).join(&key));
+                        let value = Self::map_value(value, file_origin, Pointer(&path).join(&key));
                         (key, value)
                     })
                     .collect(),
@@ -101,8 +108,8 @@ impl Json {
 
         WithOrigin {
             inner,
-            origin: Arc::new(ValueOrigin::Json {
-                filename: filename.clone(),
+            origin: Arc::new(ValueOrigin::Path {
+                source: file_origin.clone(),
                 path,
             }),
         }
@@ -115,6 +122,10 @@ impl Json {
 }
 
 impl ConfigSource for Json {
+    fn origin(&self) -> Arc<ValueOrigin> {
+        self.origin.clone()
+    }
+
     fn into_contents(self) -> ConfigContents {
         ConfigContents::Hierarchical(match self.inner.inner {
             Value::Object(map) => map,
@@ -128,6 +139,7 @@ mod tests {
     use assert_matches::assert_matches;
 
     use super::*;
+    use crate::testonly::extract_json_name;
 
     #[test]
     fn creating_json_config() {
@@ -147,14 +159,14 @@ mod tests {
         assert_eq!(bool_value.inner, Value::Bool(true));
         assert_matches!(
             bool_value.origin.as_ref(),
-            ValueOrigin::Json { filename, path } if filename.as_ref() == "test.json" && path == "bool_value"
+            ValueOrigin::Path { path, source } if path == "bool_value" && extract_json_name(source) == "test.json"
         );
 
         let str = json.inner.get(Pointer("nested.str")).unwrap();
         assert_eq!(str.inner, Value::String("???".into()));
         assert_matches!(
             str.origin.as_ref(),
-            ValueOrigin::Json { filename, path } if filename.as_ref() == "test.json" && path == "nested.str"
+            ValueOrigin::Path { path, source } if path == "nested.str" && extract_json_name(source) == "test.json"
         );
 
         json.merge("nested.str", "!!!");
@@ -188,14 +200,15 @@ mod tests {
         assert_eq!(bool_value.inner, Value::Bool(true));
         assert_matches!(
             bool_value.origin.as_ref(),
-            ValueOrigin::Json { filename, path } if path == "bool_value" && filename.contains("inline config")
+            ValueOrigin::Path { path, source }
+                if path == "bool_value" && extract_json_name(source).contains("inline config")
         );
 
         let str = json.inner.get(Pointer("nested.str")).unwrap();
         assert_eq!(str.inner, Value::String("???".into()));
         assert_matches!(
             str.origin.as_ref(),
-            ValueOrigin::Json { path, .. } if path == "nested.str"
+            ValueOrigin::Path { path, .. } if path == "nested.str"
         );
     }
 }

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -145,7 +145,7 @@ impl<'a> ConfigRepository<'a> {
                 unreachable!();
             };
 
-            for param in &*config_data.metadata.params {
+            for param in config_data.metadata.params {
                 if config_object.contains_key(param.name) {
                     continue;
                 }
@@ -181,7 +181,7 @@ impl<'a> ConfigRepository<'a> {
     ///
     /// Errors if the config is not a part of the schema or is mounted to multiple locations.
     pub fn single<C: DeserializeConfig>(&self) -> anyhow::Result<ConfigParser<'_, C>> {
-        let config_ref = self.schema.single(C::describe_config())?;
+        let config_ref = self.schema.single(&C::DESCRIPTION)?;
         Ok(ConfigParser {
             repo: self,
             config_ref,
@@ -374,7 +374,7 @@ impl WithOrigin {
             unreachable!("expected an object due to previous preprocessing steps");
         };
 
-        for param in &*metadata.params {
+        for param in metadata.params {
             if let Some(value) = map.get_mut(param.name) {
                 let Value::String(str) = &value.inner else {
                     continue;

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -40,13 +40,13 @@ pub trait ConfigSource {
 ///
 /// # Type coercion
 ///
-/// When processing [`ConfigSource`]s, values can be *coerced* depending on the [expected type](BasicType)
-/// at the corresponding location [as indicated](crate::de::DeserializeParam::expecting()) by the param deserializer.
+/// When processing [`ConfigSource`]s, values can be *coerced* depending on the [expected type](BasicTypes)
+/// at the corresponding location [as indicated](crate::de::ExpectParam::EXPECTING) by the param deserializer.
 /// Currently, coercion only happens if the original value is a string.
 ///
-/// - If the expected type is [`BasicType::Integer`], [`BasicType::Float`], or [`BasicType::Bool`],
+/// - If the expected type is [`BasicTypes::INTEGER`], [`BasicTypes::FLOAT`], or [`BasicTypes::BOOL`],
 ///   the number / Boolean is [parsed](str::parse()) from the string. If parsing succeeds, the value is replaced.
-/// - If the expected type is [`BasicType::Array`] or [`BasicType::Object`], then the original string
+/// - If the expected type is [`BasicTypes::ARRAY`], [`BasicTypes::OBJECT`], or their union, then the original string
 ///   is considered to be a JSON array / object. If JSON parsing succeeds, and the parsed value has the expected shape,
 ///   then it replaces the original value.
 ///

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -137,6 +137,7 @@ mod tests {
     #[test]
     fn complete_testing_for_env_vars() {
         let env = Environment::from_dotenv(
+            "test.env",
             r#"
             APP_INT=123
             APP_FLOAT=8.4

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -35,7 +35,7 @@ pub fn test_complete<C: DeserializeConfig>(sample: impl ConfigSource) -> Result<
     let schema = ConfigSchema::default().insert::<C>("");
     let repo = ConfigRepository::new(&schema).with(sample);
 
-    let metadata = C::describe_config();
+    let metadata = &C::DESCRIPTION;
     let mut missing_params = HashMap::new();
     let mut missing_configs = HashMap::new();
     check_params(
@@ -61,12 +61,12 @@ fn check_params(
     missing_params: &mut HashMap<String, RustType>,
     missing_configs: &mut HashMap<String, RustType>,
 ) {
-    for param in &*metadata.params {
+    for param in metadata.params {
         if sample.get(Pointer(param.name)).is_none() {
             missing_params.insert(current_path.join(param.name), param.ty);
         }
     }
-    for nested in &*metadata.nested_configs {
+    for nested in metadata.nested_configs {
         let Some(child) = sample.get(Pointer(nested.name)) else {
             missing_configs.insert(current_path.join(nested.name), nested.meta.ty);
             continue;

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -8,13 +8,14 @@ use std::{
     time::Duration,
 };
 
+use assert_matches::assert_matches;
 use serde::Deserialize;
 
 use crate::{
     de::{self, DeserializeContext, DeserializeParam, DeserializerOptions},
     metadata::{BasicType, SchemaType, SizeUnit, TimeUnit},
     source::ConfigContents,
-    value::{Value, WithOrigin},
+    value::{FileFormat, Value, ValueOrigin, WithOrigin},
     ByteSize, ConfigSource, DescribeConfig, DeserializeConfig, Environment, ParseErrors,
 };
 
@@ -197,6 +198,26 @@ pub(crate) fn test_deserialize_missing<C: DeserializeConfig>() -> Result<C, Pars
         Some(config) => Ok(config),
         None => Err(errors),
     }
+}
+
+pub(crate) fn extract_json_name(source: &ValueOrigin) -> &str {
+    if let ValueOrigin::File {
+        name,
+        format: FileFormat::Json,
+    } = source
+    {
+        name
+    } else {
+        panic!("unexpected source, expected JSON file: {source:?}");
+    }
+}
+
+pub(crate) fn extract_env_var_name(source: &ValueOrigin) -> &str {
+    let ValueOrigin::Path { path, source } = source else {
+        panic!("unexpected source: {source:?}");
+    };
+    assert_matches!(source.as_ref(), ValueOrigin::EnvVars);
+    path
 }
 
 #[cfg(test)]

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 
 use crate::{
     de::{self, DeserializeContext, DeserializeParam, DeserializerOptions},
-    metadata::{BasicType, SchemaType, SizeUnit, TimeUnit},
+    metadata::{BasicType, SizeUnit, TimeUnit},
     source::ConfigContents,
     value::{FileFormat, Value, ValueOrigin, WithOrigin},
     ByteSize, ConfigSource, DescribeConfig, DeserializeConfig, Environment, ParseErrors,
@@ -29,10 +29,9 @@ pub(crate) enum SimpleEnum {
 }
 
 impl de::WellKnown for SimpleEnum {
-    const DE: &'static dyn DeserializeParam<Self> = &SchemaType::new(BasicType::String);
+    const DE: &'static dyn DeserializeParam<Self> = &BasicType::String;
 }
 
-// FIXME: test embedding into config
 #[derive(Debug, Deserialize)]
 pub(crate) struct TestParam {
     pub int: u64,
@@ -44,6 +43,18 @@ pub(crate) struct TestParam {
     pub array: Vec<u32>,
     #[serde(default)]
     pub repeated: HashSet<SimpleEnum>,
+}
+
+impl de::WellKnown for TestParam {
+    const DE: &'static dyn DeserializeParam<Self> = &BasicType::Object;
+}
+
+#[derive(Debug, DescribeConfig, DeserializeConfig)]
+#[config(crate = crate)]
+pub(crate) struct ValueCoercingConfig {
+    pub param: TestParam,
+    #[config(default)]
+    pub set: HashSet<u64>,
 }
 
 #[derive(Debug, PartialEq, DescribeConfig, DeserializeConfig)]

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -110,7 +110,7 @@ pub(crate) struct DefaultingConfig {
     pub float: Option<f64>,
     #[config(default_t = Some("https://example.com/".into()))]
     pub url: Option<String>,
-    #[config(default, with = de::Csv(","))]
+    #[config(default, with = de::Delimited(","))]
     pub set: HashSet<SimpleEnum>,
 }
 
@@ -130,6 +130,7 @@ pub(crate) enum DefaultingEnumConfig {
 pub(crate) struct ConfigWithComplexTypes {
     #[config(default_t = 4.2)]
     pub float: f32,
+    #[config(with = de::Delimited(","))]
     pub array: [NonZeroUsize; 2],
     pub choices: Option<Vec<SimpleEnum>>,
     #[config(with = de::Optional(BasicType::Float))]
@@ -141,7 +142,7 @@ pub(crate) struct ConfigWithComplexTypes {
     #[config(with = de::Optional(SizeUnit::MiB))]
     #[config(default_t = Some(ByteSize::new(128, SizeUnit::MiB)))]
     pub memory_size_mb: Option<ByteSize>,
-    #[config(default, with = de::Csv(":"))]
+    #[config(default, with = de::Delimited(":"))]
     pub paths: Vec<PathBuf>,
 }
 

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -14,11 +14,11 @@ use assert_matches::assert_matches;
 use serde::Deserialize;
 
 use crate::{
-    de::{self, DeserializeContext, DeserializerOptions, ExpectParam},
+    de::{self, DeserializeContext, DeserializerOptions, ExpectParam, Serde},
     metadata::{BasicTypes, SizeUnit, TimeUnit},
     source::ConfigContents,
     value::{FileFormat, Value, ValueOrigin, WithOrigin},
-    ByteSize, ConfigSource, DescribeConfig, DeserializeConfig, Environment, ParseErrors, Serde,
+    ByteSize, ConfigSource, DescribeConfig, DeserializeConfig, Environment, ParseErrors,
 };
 
 #[derive(Debug, PartialEq, Eq, Hash, Deserialize)]

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -210,7 +210,7 @@ pub(crate) fn test_deserialize<C: DeserializeConfig>(val: &WithOrigin) -> Result
         &de_options,
         val,
         String::new(),
-        C::describe_config(),
+        &C::DESCRIPTION,
         &mut errors,
     );
     match C::deserialize_config(ctx) {
@@ -227,7 +227,7 @@ pub(crate) fn test_deserialize_missing<C: DeserializeConfig>() -> Result<C, Pars
         &de_options,
         &val,
         "test".into(),
-        C::describe_config(),
+        &C::DESCRIPTION,
         &mut errors,
     );
     match C::deserialize_config(ctx) {

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -168,7 +168,7 @@ pub(crate) struct ConfigWithComplexTypes {
     #[config(with = de::Delimited(","))]
     pub array: [NonZeroUsize; 2],
     pub choices: Option<Vec<SimpleEnum>>,
-    #[config(with = de::Optional(Serde![BasicTypes::FLOAT]))]
+    #[config(with = de::Optional(Serde![float]))]
     pub assumed: Option<serde_json::Value>,
     #[config(default_t = Duration::from_millis(100), with = TimeUnit::Millis)]
     pub short_dur: Duration,
@@ -179,7 +179,7 @@ pub(crate) struct ConfigWithComplexTypes {
     pub memory_size_mb: Option<ByteSize>,
     #[config(default, with = de::Delimited(":"))]
     pub paths: Vec<PathBuf>,
-    #[config(default, with = de::OrString)]
+    #[config(default, with = de::OrString(Serde![object]))]
     pub map_or_string: MapOrString,
 }
 

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -110,7 +110,7 @@ pub(crate) struct DefaultingConfig {
     pub float: Option<f64>,
     #[config(default_t = Some("https://example.com/".into()))]
     pub url: Option<String>,
-    #[config(default)]
+    #[config(default, with = de::Csv(","))]
     pub set: HashSet<SimpleEnum>,
 }
 
@@ -141,6 +141,8 @@ pub(crate) struct ConfigWithComplexTypes {
     #[config(with = de::Optional(SizeUnit::MiB))]
     #[config(default_t = Some(ByteSize::new(128, SizeUnit::MiB)))]
     pub memory_size_mb: Option<ByteSize>,
+    #[config(default, with = de::Csv(":"))]
+    pub paths: Vec<PathBuf>,
 }
 
 pub(crate) fn wrap_into_value(env: Environment) -> WithOrigin {

--- a/crates/smart-config/src/value.rs
+++ b/crates/smart-config/src/value.rs
@@ -32,7 +32,7 @@ impl fmt::Display for FileFormat {
 pub enum ValueOrigin {
     /// Unknown / default origin.
     #[default]
-    Unknown, // FIXME: remove?
+    Unknown,
     /// Environment variables.
     EnvVars,
     /// File source.

--- a/crates/smart-config/src/value.rs
+++ b/crates/smart-config/src/value.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, fmt, iter, sync::Arc};
 
-use crate::metadata::BasicType;
+use crate::metadata::BasicTypes;
 
 /// Supported file formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -99,16 +99,18 @@ pub enum Value {
 }
 
 impl Value {
-    pub(crate) fn basic_type(&self) -> Option<BasicType> {
-        Some(match self {
-            Self::Null => return None,
-            Self::Bool(_) => BasicType::Bool,
-            Self::Number(number) if number.is_u64() || number.is_i64() => BasicType::Integer,
-            Self::Number(_) => BasicType::Float,
-            Self::String(_) => BasicType::String,
-            Self::Array(_) => BasicType::Array,
-            Self::Object(_) => BasicType::Object,
-        })
+    pub(crate) fn is_supported_by(&self, types: BasicTypes) -> bool {
+        match self {
+            Self::Null => true,
+            Self::Bool(_) => types.contains(BasicTypes::BOOL),
+            Self::Number(number) if number.is_u64() || number.is_i64() => {
+                types.contains(BasicTypes::INTEGER)
+            }
+            Self::Number(_) => types.contains(BasicTypes::FLOAT),
+            Self::String(_) => types.contains(BasicTypes::STRING),
+            Self::Array(_) => types.contains(BasicTypes::ARRAY),
+            Self::Object(_) => types.contains(BasicTypes::OBJECT),
+        }
     }
 
     /// Attempts to convert this value to an object.


### PR DESCRIPTION
# What ❔

- Removes arguably bogus string -> array coercion from the serde deserializer. Replaces it with 2 mechanisms: additional param deserializers (`Delimited` and `OrString`), and automated JSON string -> JSON parsing for params expecting an object and/or array.
- Refactors `ValueOrigin`s to be more consistent and provide more info.
- Refactors param deserializers to have expected input shape as a constant, and allows to specify multiple supported shapes. This slightly complicates the default serializer (IMO, to a reasonable degree), but has multiple benefits, such as allowing to check compatibility for deserializer decorators in compile time.
- Rework metadata so that it's created in compile time. This can be used in compile-time checks (plan to implement them separately).

## Why ❔

Maintainability; see above.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.