### PR TITLE
fix: Implement consistent collection deserializer

### DIFF
--- a/crates/smart-config-derive/src/describe.rs
+++ b/crates/smart-config-derive/src/describe.rs
@@ -98,8 +98,8 @@ impl ConfigField {
                 help: #help,
                 rust_field_name: ::core::stringify!(#name),
                 rust_type: #cr::metadata::RustType::of::<#ty>(#ty_in_code),
-                expecting: #cr::de::extract_expected_types::<#ty, _>(&deserializer),
-                deserializer: &#cr::de::Erased::<#ty, _>::new(deserializer),
+                expecting: #cr::de::_private::extract_expected_types::<#ty, _>(&deserializer),
+                deserializer: &#cr::de::_private::Erased::<#ty, _>::new(deserializer),
                 default_value: #default_value,
             }
         }}

--- a/crates/smart-config-derive/src/utils.rs
+++ b/crates/smart-config-derive/src/utils.rs
@@ -258,7 +258,7 @@ impl ConfigField {
         // FIXME: use `WithDefault` here?
         let default_opt = wrap_in_option(default.map(|val| quote!(#val)));
         let with = syn::parse_quote! {
-            #cr::de::TagDeserializer::new(&[#(#variants,)*], #default_opt)
+            #cr::de::_private::TagDeserializer::new(&[#(#variants,)*], #default_opt)
         };
 
         Self {

--- a/crates/smart-config/src/de/_private.rs
+++ b/crates/smart-config/src/de/_private.rs
@@ -1,0 +1,113 @@
+//! Private functionality used by derive macros. Not part of the public API.
+
+use std::{any, fmt, marker::PhantomData};
+
+use serde::{de::Error as DeError, Deserialize};
+
+use super::{deserializer::ValueDeserializer, DeserializeContext, DeserializeParam};
+use crate::{
+    error::ErrorWithOrigin,
+    metadata::{BasicTypes, ParamMetadata, TypeQualifiers},
+};
+
+pub const fn extract_expected_types<T, De: DeserializeParam<T>>(_: &De) -> BasicTypes {
+    <De as DeserializeParam<T>>::EXPECTING
+}
+
+/// Erased counterpart of a parameter deserializer. Stored in param metadata.
+pub trait ErasedDeserializer: fmt::Debug + Send + Sync + 'static {
+    fn type_qualifiers(&self) -> TypeQualifiers;
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<Box<dyn any::Any>, ErrorWithOrigin>;
+}
+
+/// Wrapper transforming [`DeserializeParam`] to [`ErasedDeserializer`].
+pub struct Erased<T, De> {
+    inner: De,
+    _ty: PhantomData<fn(T)>,
+}
+
+impl<T, D: fmt::Debug> fmt::Debug for Erased<T, D> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("Erased").field(&self.inner).finish()
+    }
+}
+
+impl<T: 'static, De: DeserializeParam<T>> Erased<T, De> {
+    pub const fn new(inner: De) -> Self {
+        Self {
+            inner,
+            _ty: PhantomData,
+        }
+    }
+}
+
+impl<T: 'static, De: DeserializeParam<T>> ErasedDeserializer for Erased<T, De> {
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        self.inner.type_qualifiers()
+    }
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<Box<dyn any::Any>, ErrorWithOrigin> {
+        self.inner
+            .deserialize_param(ctx, param)
+            .map(|val| Box::new(val) as _)
+    }
+}
+
+/// Deserializer for enum tags.
+#[derive(Debug)]
+pub struct TagDeserializer {
+    expected: &'static [&'static str],
+    default_value: Option<&'static str>,
+}
+
+impl TagDeserializer {
+    pub const fn new(
+        expected: &'static [&'static str],
+        default_value: Option<&'static str>,
+    ) -> Self {
+        Self {
+            expected,
+            default_value,
+        }
+    }
+}
+
+impl DeserializeParam<&'static str> for TagDeserializer {
+    const EXPECTING: BasicTypes = BasicTypes::STRING;
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<&'static str, ErrorWithOrigin> {
+        let s = if let Some(current_value) = ctx.current_value() {
+            String::deserialize(ValueDeserializer::new(current_value, ctx.de_options))?
+        } else if let Some(default) = self.default_value {
+            return Ok(default);
+        } else {
+            return Err(DeError::missing_field(param.name));
+        };
+
+        self.expected
+            .iter()
+            .copied()
+            .find(|&variant| variant == s)
+            .ok_or_else(|| {
+                let err = DeError::unknown_variant(&s, self.expected);
+                let origin = ctx
+                    .current_value()
+                    .map(|val| val.origin.clone())
+                    .unwrap_or_default();
+                ErrorWithOrigin::json(err, origin)
+            })
+    }
+}

--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -61,8 +61,12 @@ impl<'a> ValueDeserializer<'a> {
         &self.value.inner
     }
 
+    pub(super) fn origin(&self) -> &Arc<ValueOrigin> {
+        &self.value.origin
+    }
+
     pub(super) fn enrich_err(&self, err: serde_json::Error) -> ErrorWithOrigin {
-        ErrorWithOrigin::new(err, self.value.origin.clone())
+        ErrorWithOrigin::json(err, self.value.origin.clone())
     }
 
     #[cold]
@@ -365,7 +369,7 @@ impl<'a, 'de> de::EnumAccess<'de> for EnumDeserializer<'a> {
         let variant = self.variant.into_deserializer();
         match seed.deserialize(variant) {
             Ok(val) => Ok((val, self.inner)),
-            Err(err) => Err(ErrorWithOrigin::new(err, self.inner.origin().clone())),
+            Err(err) => Err(ErrorWithOrigin::json(err, self.inner.origin().clone())),
         }
     }
 }
@@ -402,7 +406,7 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_> {
             seed.deserialize(ValueDeserializer::new(value, self.options))
         } else {
             let err = DeError::invalid_type(de::Unexpected::Unit, &"newtype variant");
-            Err(ErrorWithOrigin::new(err, self.parent_origin))
+            Err(ErrorWithOrigin::json(err, self.parent_origin))
         }
     }
 
@@ -415,7 +419,7 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_> {
             de::Deserializer::deserialize_seq(ValueDeserializer::new(value, self.options), visitor)
         } else {
             let err = DeError::invalid_type(de::Unexpected::Unit, &"tuple variant");
-            Err(ErrorWithOrigin::new(err, self.parent_origin))
+            Err(ErrorWithOrigin::json(err, self.parent_origin))
         }
     }
 
@@ -428,7 +432,7 @@ impl<'de> de::VariantAccess<'de> for VariantDeserializer<'_> {
             de::Deserializer::deserialize_map(ValueDeserializer::new(value, self.options), visitor)
         } else {
             let err = DeError::invalid_type(de::Unexpected::Unit, &"struct variant");
-            Err(ErrorWithOrigin::new(err, self.parent_origin))
+            Err(ErrorWithOrigin::json(err, self.parent_origin))
         }
     }
 }

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -39,15 +39,11 @@ use std::sync::Arc;
 use serde::de::Error as DeError;
 
 use self::deserializer::ValueDeserializer;
-#[doc(hidden)]
-pub use self::param::{Erased, ErasedDeserializer, TagDeserializer};
 pub use self::{
     deserializer::DeserializerOptions,
     macros::Serde,
-    param::{
-        Delimited, DeserializeParam, Optional, OrString, Qualified, Serde, WellKnown, WithDefault,
-    },
-    repeated::Repeated,
+    param::{DeserializeParam, Optional, OrString, Qualified, Serde, WellKnown, WithDefault},
+    repeated::{Delimited, Repeated},
 };
 use crate::{
     error::{ErrorWithOrigin, LocationInConfig, LowLevelError},
@@ -56,6 +52,8 @@ use crate::{
     DescribeConfig, Json, ParseError, ParseErrors,
 };
 
+#[doc(hidden)]
+pub mod _private;
 mod deserializer;
 mod macros;
 mod param;
@@ -64,11 +62,6 @@ mod primitive_types_impl;
 mod repeated;
 #[cfg(test)]
 mod tests;
-
-#[doc(hidden)] // used by proc macros
-pub const fn extract_expected_types<T, De: DeserializeParam<T>>(_: &De) -> BasicTypes {
-    <De as DeserializeParam<T>>::EXPECTING
-}
 
 /// Context for deserializing a configuration.
 #[derive(Debug)]

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -47,6 +47,7 @@ pub use self::{
     param::{
         Delimited, DeserializeParam, Optional, OrString, Qualified, Serde, WellKnown, WithDefault,
     },
+    repeated::Repeated,
 };
 use crate::{
     error::{ErrorWithOrigin, LocationInConfig, LowLevelError},
@@ -60,6 +61,7 @@ mod macros;
 mod param;
 #[cfg(feature = "primitive-types")]
 mod primitive_types_impl;
+mod repeated;
 #[cfg(test)]
 mod tests;
 

--- a/crates/smart-config/src/de/param.rs
+++ b/crates/smart-config/src/de/param.rs
@@ -1,10 +1,7 @@
 //! Parameter deserializers.
 
 use std::{
-    any,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    fmt,
-    hash::{BuildHasher, Hash},
+    any, fmt,
     marker::PhantomData,
     num::{
         NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU16, NonZeroU32,
@@ -23,7 +20,7 @@ use serde::{
 
 use crate::{
     de::{deserializer::ValueDeserializer, DeserializeContext},
-    error::{ErrorWithOrigin, LowLevelError},
+    error::ErrorWithOrigin,
     metadata::{BasicTypes, ParamMetadata, SizeUnit, TimeUnit, TypeQualifiers},
     value::{Value, ValueOrigin, WithOrigin},
     ByteSize,
@@ -83,7 +80,7 @@ pub trait DeserializeParam<T>: fmt::Debug + Send + Sync + 'static {
 /// It is also implemented for collections, items of which implement `WellKnown`:
 ///
 /// - [`Option`]
-/// - [`Vec`], arrays up to 32 elements (which is a `serde` restriction, not a local one)
+/// - [`Vec`], arrays
 /// - [`HashSet`], [`BTreeSet`]
 /// - [`HashMap`], [`BTreeMap`]
 #[diagnostic::on_unimplemented(
@@ -204,278 +201,6 @@ impl<T: WellKnown> WellKnown for Option<T> {
     const DE: Self::Deserializer = Optional(T::DE);
 }
 
-#[derive(Debug)]
-pub struct Repeated<De>(pub De);
-
-impl<De> Repeated<De> {
-    fn deserialize_array<T, C>(
-        &self,
-        mut ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-        expected_len: Option<usize>,
-    ) -> Result<C, ErrorWithOrigin>
-    where
-        De: DeserializeParam<T>,
-        C: FromIterator<T>,
-    {
-        let deserializer = ctx.current_value_deserializer(param.name)?;
-        let Value::Array(items) = deserializer.value() else {
-            return Err(deserializer.invalid_type("array"));
-        };
-
-        if let Some(expected_len) = expected_len {
-            if items.len() != expected_len {
-                let err = DeError::invalid_length(items.len(), &expected_len.to_string().as_str());
-                return Err(deserializer.enrich_err(err));
-            }
-        }
-
-        let mut has_errors = false;
-        let items = items.iter().enumerate().filter_map(|(i, item)| {
-            let coerced = item.coerce_value_type(De::EXPECTING);
-            let mut child_ctx = ctx.child(&i.to_string(), ctx.location_in_config);
-            let mut child_ctx = child_ctx.patched(coerced.as_ref().unwrap_or(item));
-            match self.0.deserialize_param(child_ctx.borrow(), param) {
-                Ok(val) if !has_errors => Some(val),
-                Ok(_) => None, // Drop the value since it won't be needed anyway
-                Err(err) => {
-                    has_errors = true;
-                    child_ctx.push_error(err);
-                    None
-                }
-            }
-        });
-        let items: C = items.collect();
-
-        if has_errors {
-            let origin = deserializer.origin().clone();
-            Err(ErrorWithOrigin::new(LowLevelError::InvalidArray, origin))
-        } else {
-            Ok(items)
-        }
-    }
-
-    fn deserialize_map<K, V, C>(
-        &self,
-        mut ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<C, ErrorWithOrigin>
-    where
-        K: FromStr<Err: fmt::Display>,
-        De: DeserializeParam<V>,
-        C: FromIterator<(K, V)>,
-    {
-        let deserializer = ctx.current_value_deserializer(param.name)?;
-        let Value::Object(items) = deserializer.value() else {
-            return Err(deserializer.invalid_type("object"));
-        };
-
-        let mut has_errors = false;
-        let items = items.iter().filter_map(|(key, value)| {
-            let coerced = value.coerce_value_type(De::EXPECTING);
-            let mut child_ctx = ctx.child(key, ctx.location_in_config);
-            let mut child_ctx = child_ctx.patched(coerced.as_ref().unwrap_or(value));
-
-            let key = match key.parse::<K>() {
-                Ok(val) if !has_errors => Some(val),
-                Ok(_) => None,
-                Err(err) => {
-                    has_errors = true;
-                    child_ctx.push_error(DeError::custom(format!("cannot deserialize key: {err}")));
-                    None
-                }
-            };
-            let value = match self.0.deserialize_param(child_ctx.borrow(), param) {
-                Ok(val) if !has_errors => Some(val),
-                Ok(_) => None,
-                Err(err) => {
-                    has_errors = true;
-                    child_ctx.push_error(err);
-                    None
-                }
-            };
-            Some((key?, value?))
-        });
-        let items: C = items.collect();
-
-        if has_errors {
-            let origin = deserializer.origin().clone();
-            Err(ErrorWithOrigin::new(LowLevelError::InvalidObject, origin))
-        } else {
-            Ok(items)
-        }
-    }
-}
-
-impl<T, De> DeserializeParam<Vec<T>> for Repeated<De>
-where
-    De: DeserializeParam<T>,
-{
-    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<Vec<T>, ErrorWithOrigin> {
-        self.deserialize_array(ctx, param, None)
-    }
-}
-
-impl<T, S, De> DeserializeParam<HashSet<T, S>> for Repeated<De>
-where
-    T: Eq + Hash,
-    S: 'static + Default + BuildHasher,
-    De: DeserializeParam<T>,
-{
-    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
-
-    fn type_qualifiers(&self) -> TypeQualifiers {
-        TypeQualifiers::new("set")
-    }
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<HashSet<T, S>, ErrorWithOrigin> {
-        self.deserialize_array(ctx, param, None)
-    }
-}
-
-impl<T, De> DeserializeParam<BTreeSet<T>> for Repeated<De>
-where
-    T: Eq + Ord,
-    De: DeserializeParam<T>,
-{
-    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
-
-    fn type_qualifiers(&self) -> TypeQualifiers {
-        TypeQualifiers::new("set")
-    }
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<BTreeSet<T>, ErrorWithOrigin> {
-        self.deserialize_array(ctx, param, None)
-    }
-}
-
-impl<T, De, const N: usize> DeserializeParam<[T; N]> for Repeated<De>
-where
-    De: DeserializeParam<T>,
-{
-    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
-
-    fn type_qualifiers(&self) -> TypeQualifiers {
-        TypeQualifiers::new("fixed-sized array")
-    }
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<[T; N], ErrorWithOrigin> {
-        let items: Vec<_> = self.deserialize_array(ctx, param, Some(N))?;
-        // `unwrap()` is safe due to the length check in `deserialize_inner()`
-        Ok(items.try_into().ok().unwrap())
-    }
-}
-
-impl<T: WellKnown> WellKnown for Vec<T> {
-    type Deserializer = Repeated<T::Deserializer>;
-    const DE: Self::Deserializer = Repeated(T::DE);
-}
-
-impl<T: WellKnown, const N: usize> WellKnown for [T; N] {
-    type Deserializer = Repeated<T::Deserializer>;
-    const DE: Self::Deserializer = Repeated(T::DE);
-}
-
-// Heterogeneous tuples don't look like a good idea to mark as well-known because they wouldn't look well-structured
-// (it'd be better to define either multiple params or a struct param).
-
-impl<T, S> WellKnown for HashSet<T, S>
-where
-    T: Eq + Hash + WellKnown,
-    S: 'static + Default + BuildHasher,
-{
-    type Deserializer = Repeated<T::Deserializer>;
-    const DE: Self::Deserializer = Repeated(T::DE);
-}
-
-impl<T> WellKnown for BTreeSet<T>
-where
-    T: Eq + Ord + WellKnown,
-{
-    type Deserializer = Repeated<T::Deserializer>;
-    const DE: Self::Deserializer = Repeated(T::DE);
-}
-
-impl<K, V, S, De> DeserializeParam<HashMap<K, V, S>> for Repeated<De>
-where
-    K: 'static + Eq + Hash + FromStr<Err: fmt::Display>,
-    S: 'static + Default + BuildHasher,
-    De: DeserializeParam<V>,
-{
-    const EXPECTING: BasicTypes = BasicTypes::OBJECT;
-
-    fn type_qualifiers(&self) -> TypeQualifiers {
-        TypeQualifiers::new("map")
-    }
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<HashMap<K, V, S>, ErrorWithOrigin> {
-        self.deserialize_map(ctx, param)
-    }
-}
-
-impl<K, V, De> DeserializeParam<BTreeMap<K, V>> for Repeated<De>
-where
-    K: 'static + Eq + Ord + FromStr<Err: fmt::Display>,
-    De: DeserializeParam<V>,
-{
-    const EXPECTING: BasicTypes = BasicTypes::OBJECT;
-
-    fn type_qualifiers(&self) -> TypeQualifiers {
-        TypeQualifiers::new("map")
-    }
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<BTreeMap<K, V>, ErrorWithOrigin> {
-        self.deserialize_map(ctx, param)
-    }
-}
-
-/// Keys are intentionally restricted by [`FromStr`] in order to prevent runtime errors when dealing with keys
-/// that do not serialize to strings.
-impl<K, V, S> WellKnown for HashMap<K, V, S>
-where
-    K: 'static + Eq + Hash + FromStr<Err: fmt::Display>,
-    V: WellKnown,
-    S: 'static + Default + BuildHasher,
-{
-    type Deserializer = Repeated<V::Deserializer>;
-    const DE: Self::Deserializer = Repeated(V::DE);
-}
-
-impl<K, V> WellKnown for BTreeMap<K, V>
-where
-    K: 'static + Eq + Ord + FromStr<Err: fmt::Display>,
-    V: WellKnown,
-{
-    type Deserializer = Repeated<V::Deserializer>;
-    const DE: Self::Deserializer = Repeated(V::DE);
-}
-
 /// [Deserializer](DeserializeParam) decorator that provides additional [qualifiers](TypeQualifiers)
 /// for the deserialized type.
 #[derive(Debug)]
@@ -498,16 +223,16 @@ where
 {
     const EXPECTING: BasicTypes = <De as DeserializeParam<T>>::EXPECTING;
 
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        TypeQualifiers::new(self.description)
+    }
+
     fn deserialize_param(
         &self,
         ctx: DeserializeContext<'_>,
         param: &'static ParamMetadata,
     ) -> Result<T, ErrorWithOrigin> {
         self.inner.deserialize_param(ctx, param)
-    }
-
-    fn type_qualifiers(&self) -> TypeQualifiers {
-        TypeQualifiers::new(self.description)
     }
 }
 

--- a/crates/smart-config/src/de/repeated.rs
+++ b/crates/smart-config/src/de/repeated.rs
@@ -80,7 +80,8 @@ impl<De> Repeated<De> {
         param: &'static ParamMetadata,
     ) -> Result<C, ErrorWithOrigin>
     where
-        K: FromStr<Err: fmt::Display>,
+        K: FromStr,
+        K::Err: fmt::Display,
         De: DeserializeParam<V>,
         C: FromIterator<(K, V)>,
     {
@@ -235,7 +236,8 @@ where
 
 impl<K, V, S, De> DeserializeParam<HashMap<K, V, S>> for Repeated<De>
 where
-    K: 'static + Eq + Hash + FromStr<Err: fmt::Display>,
+    K: 'static + Eq + Hash + FromStr,
+    K::Err: fmt::Display,
     S: 'static + Default + BuildHasher,
     De: DeserializeParam<V>,
 {
@@ -256,7 +258,8 @@ where
 
 impl<K, V, De> DeserializeParam<BTreeMap<K, V>> for Repeated<De>
 where
-    K: 'static + Eq + Ord + FromStr<Err: fmt::Display>,
+    K: 'static + Eq + Ord + FromStr,
+    K::Err: fmt::Display,
     De: DeserializeParam<V>,
 {
     const EXPECTING: BasicTypes = BasicTypes::OBJECT;
@@ -276,7 +279,8 @@ where
 
 impl<K, V, S> WellKnown for HashMap<K, V, S>
 where
-    K: 'static + Eq + Hash + FromStr<Err: fmt::Display>,
+    K: 'static + Eq + Hash + FromStr,
+    K::Err: fmt::Display,
     V: WellKnown,
     S: 'static + Default + BuildHasher,
 {
@@ -286,7 +290,8 @@ where
 
 impl<K, V> WellKnown for BTreeMap<K, V>
 where
-    K: 'static + Eq + Ord + FromStr<Err: fmt::Display>,
+    K: 'static + Eq + Ord + FromStr,
+    K::Err: fmt::Display,
     V: WellKnown,
 {
     type Deserializer = Repeated<V::Deserializer>;

--- a/crates/smart-config/src/de/repeated.rs
+++ b/crates/smart-config/src/de/repeated.rs
@@ -1,0 +1,293 @@
+//! `Repeated` deserializer for arrays / objects.
+
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    fmt,
+    hash::{BuildHasher, Hash},
+    str::FromStr,
+};
+
+use serde::de::Error as DeError;
+
+use crate::{
+    de::{DeserializeContext, DeserializeParam, WellKnown},
+    error::{ErrorWithOrigin, LowLevelError},
+    metadata::{BasicTypes, ParamMetadata, TypeQualifiers},
+    value::Value,
+};
+
+/// Deserializer from JSON arrays and objects.
+///
+/// Supports the following param types:
+///
+/// - [`Vec`], arrays, [`HashSet`], [`BTreeSet`] when deserializing from an array
+/// - [`HashMap`] and [`BTreeMap`] when deserializing from an object
+#[derive(Debug)]
+pub struct Repeated<De>(pub De);
+
+impl<De> Repeated<De> {
+    fn deserialize_array<T, C>(
+        &self,
+        mut ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+        expected_len: Option<usize>,
+    ) -> Result<C, ErrorWithOrigin>
+    where
+        De: DeserializeParam<T>,
+        C: FromIterator<T>,
+    {
+        let deserializer = ctx.current_value_deserializer(param.name)?;
+        let Value::Array(items) = deserializer.value() else {
+            return Err(deserializer.invalid_type("array"));
+        };
+
+        if let Some(expected_len) = expected_len {
+            if items.len() != expected_len {
+                let err = DeError::invalid_length(items.len(), &expected_len.to_string().as_str());
+                return Err(deserializer.enrich_err(err));
+            }
+        }
+
+        let mut has_errors = false;
+        let items = items.iter().enumerate().filter_map(|(i, item)| {
+            let coerced = item.coerce_value_type(De::EXPECTING);
+            let mut child_ctx = ctx.child(&i.to_string(), ctx.location_in_config);
+            let mut child_ctx = child_ctx.patched(coerced.as_ref().unwrap_or(item));
+            match self.0.deserialize_param(child_ctx.borrow(), param) {
+                Ok(val) if !has_errors => Some(val),
+                Ok(_) => None, // Drop the value since it won't be needed anyway
+                Err(err) => {
+                    has_errors = true;
+                    child_ctx.push_error(err);
+                    None
+                }
+            }
+        });
+        let items: C = items.collect();
+
+        if has_errors {
+            let origin = deserializer.origin().clone();
+            Err(ErrorWithOrigin::new(LowLevelError::InvalidArray, origin))
+        } else {
+            Ok(items)
+        }
+    }
+
+    fn deserialize_map<K, V, C>(
+        &self,
+        mut ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<C, ErrorWithOrigin>
+    where
+        K: FromStr<Err: fmt::Display>,
+        De: DeserializeParam<V>,
+        C: FromIterator<(K, V)>,
+    {
+        let deserializer = ctx.current_value_deserializer(param.name)?;
+        let Value::Object(items) = deserializer.value() else {
+            return Err(deserializer.invalid_type("object"));
+        };
+
+        let mut has_errors = false;
+        let items = items.iter().filter_map(|(key, value)| {
+            let coerced = value.coerce_value_type(De::EXPECTING);
+            let mut child_ctx = ctx.child(key, ctx.location_in_config);
+            let mut child_ctx = child_ctx.patched(coerced.as_ref().unwrap_or(value));
+
+            let key = match key.parse::<K>() {
+                Ok(val) if !has_errors => Some(val),
+                Ok(_) => None,
+                Err(err) => {
+                    has_errors = true;
+                    child_ctx.push_error(DeError::custom(format!("cannot deserialize key: {err}")));
+                    None
+                }
+            };
+            let value = match self.0.deserialize_param(child_ctx.borrow(), param) {
+                Ok(val) if !has_errors => Some(val),
+                Ok(_) => None,
+                Err(err) => {
+                    has_errors = true;
+                    child_ctx.push_error(err);
+                    None
+                }
+            };
+            Some((key?, value?))
+        });
+        let items: C = items.collect();
+
+        if has_errors {
+            let origin = deserializer.origin().clone();
+            Err(ErrorWithOrigin::new(LowLevelError::InvalidObject, origin))
+        } else {
+            Ok(items)
+        }
+    }
+}
+
+impl<T, De> DeserializeParam<Vec<T>> for Repeated<De>
+where
+    De: DeserializeParam<T>,
+{
+    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<Vec<T>, ErrorWithOrigin> {
+        self.deserialize_array(ctx, param, None)
+    }
+}
+
+impl<T, S, De> DeserializeParam<HashSet<T, S>> for Repeated<De>
+where
+    T: Eq + Hash,
+    S: 'static + Default + BuildHasher,
+    De: DeserializeParam<T>,
+{
+    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
+
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        TypeQualifiers::new("set")
+    }
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<HashSet<T, S>, ErrorWithOrigin> {
+        self.deserialize_array(ctx, param, None)
+    }
+}
+
+impl<T, De> DeserializeParam<BTreeSet<T>> for Repeated<De>
+where
+    T: Eq + Ord,
+    De: DeserializeParam<T>,
+{
+    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
+
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        TypeQualifiers::new("set")
+    }
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<BTreeSet<T>, ErrorWithOrigin> {
+        self.deserialize_array(ctx, param, None)
+    }
+}
+
+impl<T, De, const N: usize> DeserializeParam<[T; N]> for Repeated<De>
+where
+    De: DeserializeParam<T>,
+{
+    const EXPECTING: BasicTypes = BasicTypes::ARRAY;
+
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        TypeQualifiers::new("fixed-sized array")
+    }
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<[T; N], ErrorWithOrigin> {
+        let items: Vec<_> = self.deserialize_array(ctx, param, Some(N))?;
+        // `unwrap()` is safe due to the length check in `deserialize_inner()`
+        Ok(items.try_into().ok().unwrap())
+    }
+}
+
+impl<T: WellKnown> WellKnown for Vec<T> {
+    type Deserializer = Repeated<T::Deserializer>;
+    const DE: Self::Deserializer = Repeated(T::DE);
+}
+
+impl<T: WellKnown, const N: usize> WellKnown for [T; N] {
+    type Deserializer = Repeated<T::Deserializer>;
+    const DE: Self::Deserializer = Repeated(T::DE);
+}
+
+// Heterogeneous tuples don't look like a good idea to mark as well-known because they wouldn't look well-structured
+// (it'd be better to define either multiple params or a struct param).
+
+impl<T, S> WellKnown for HashSet<T, S>
+where
+    T: Eq + Hash + WellKnown,
+    S: 'static + Default + BuildHasher,
+{
+    type Deserializer = Repeated<T::Deserializer>;
+    const DE: Self::Deserializer = Repeated(T::DE);
+}
+
+impl<T> WellKnown for BTreeSet<T>
+where
+    T: Eq + Ord + WellKnown,
+{
+    type Deserializer = Repeated<T::Deserializer>;
+    const DE: Self::Deserializer = Repeated(T::DE);
+}
+
+impl<K, V, S, De> DeserializeParam<HashMap<K, V, S>> for Repeated<De>
+where
+    K: 'static + Eq + Hash + FromStr<Err: fmt::Display>,
+    S: 'static + Default + BuildHasher,
+    De: DeserializeParam<V>,
+{
+    const EXPECTING: BasicTypes = BasicTypes::OBJECT;
+
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        TypeQualifiers::new("map")
+    }
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<HashMap<K, V, S>, ErrorWithOrigin> {
+        self.deserialize_map(ctx, param)
+    }
+}
+
+impl<K, V, De> DeserializeParam<BTreeMap<K, V>> for Repeated<De>
+where
+    K: 'static + Eq + Ord + FromStr<Err: fmt::Display>,
+    De: DeserializeParam<V>,
+{
+    const EXPECTING: BasicTypes = BasicTypes::OBJECT;
+
+    fn type_qualifiers(&self) -> TypeQualifiers {
+        TypeQualifiers::new("map")
+    }
+
+    fn deserialize_param(
+        &self,
+        ctx: DeserializeContext<'_>,
+        param: &'static ParamMetadata,
+    ) -> Result<BTreeMap<K, V>, ErrorWithOrigin> {
+        self.deserialize_map(ctx, param)
+    }
+}
+
+impl<K, V, S> WellKnown for HashMap<K, V, S>
+where
+    K: 'static + Eq + Hash + FromStr<Err: fmt::Display>,
+    V: WellKnown,
+    S: 'static + Default + BuildHasher,
+{
+    type Deserializer = Repeated<V::Deserializer>;
+    const DE: Self::Deserializer = Repeated(V::DE);
+}
+
+impl<K, V> WellKnown for BTreeMap<K, V>
+where
+    K: 'static + Eq + Ord + FromStr<Err: fmt::Display>,
+    V: WellKnown,
+{
+    type Deserializer = Repeated<V::Deserializer>;
+    const DE: Self::Deserializer = Repeated(V::DE);
+}

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -443,7 +443,7 @@ fn error_parsing_array_from_string() {
     let err = test_deserialize::<ConfigWithComplexTypes>(json.inner()).unwrap_err();
     assert_eq!(err.len(), 1);
     let err = err.first();
-    assert_eq!(err.path(), "array");
+    assert_eq!(err.path(), "array.1");
     let inner = err.inner().to_string();
     assert!(inner.contains("what"), "{inner}");
 
@@ -496,7 +496,7 @@ fn parsing_complex_types_errors() {
     let err = errors.first();
     let inner = err.inner().to_string();
     assert!(inner.contains("nonzero"), "{inner}");
-    assert_eq!(err.path(), "array");
+    assert_eq!(err.path(), "array.0");
     assert_matches!(err.origin(), ValueOrigin::Path { path, .. } if path == "array.0");
 
     let json = config!("array": [2, 3], "float": "what");

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -14,7 +14,7 @@ use crate::{
     metadata::SizeUnit,
     testonly::{
         extract_env_var_name, extract_json_name, test_deserialize, test_deserialize_missing,
-        wrap_into_value, CompoundConfig, ConfigWithComplexTypes, ConfigWithNesting,
+        wrap_into_value, ComposedConfig, CompoundConfig, ConfigWithComplexTypes, ConfigWithNesting,
         DefaultingConfig, DefaultingEnumConfig, EnumConfig, MapOrString, NestedConfig,
         RenamedEnumConfig, SimpleEnum, TestParam,
     },
@@ -448,6 +448,40 @@ fn parsing_complex_types() {
 }
 
 #[test]
+fn parsing_composed_params() {
+    let json = config!("durations": ["1sec", "5 min"]);
+    let config: ComposedConfig = test_deserialize(json.inner()).unwrap();
+    let expected_array = [Duration::from_secs(1), Duration::from_secs(300)];
+    assert_eq!(config.durations, expected_array);
+
+    let json = config!(
+        "durations": serde_json::json!(["1 sec", { "min": 5 }])
+    );
+    let config: ComposedConfig = test_deserialize(json.inner()).unwrap();
+    assert_eq!(config.durations, expected_array);
+
+    let json = config!("delimited_durations": ["1sec", "5 min"]);
+    let config: ComposedConfig = test_deserialize(json.inner()).unwrap();
+    assert_eq!(config.delimited_durations, expected_array);
+
+    let json = config!("delimited_durations": "1 sec,5 min");
+    let config: ComposedConfig = test_deserialize(json.inner()).unwrap();
+    assert_eq!(config.delimited_durations, expected_array);
+
+    let json = config!("map_of_sizes": HashMap::from([("small", "1 MiB"), ("large", "3 MiB")]));
+    let config: ComposedConfig = test_deserialize(json.inner()).unwrap();
+    let expected_map = HashMap::from([
+        ("small".to_owned(), ByteSize(1 << 20)),
+        ("large".to_owned(), ByteSize(3 << 20)),
+    ]);
+    assert_eq!(config.map_of_sizes, expected_map);
+
+    let json = config!("map_of_ints": HashMap::from([(5, "30 sec")]));
+    let config: ComposedConfig = test_deserialize(json.inner()).unwrap();
+    assert_eq!(config.map_of_ints[&5], Duration::from_secs(30));
+}
+
+#[test]
 fn error_parsing_array_from_string() {
     let json = config!("array": "4,what");
     let err = test_deserialize::<ConfigWithComplexTypes>(json.inner()).unwrap_err();
@@ -527,4 +561,50 @@ fn parsing_complex_types_errors() {
     );
     assert_eq!(err.path(), "assumed");
     assert_matches!(err.origin(), ValueOrigin::Path { path, .. } if path == "assumed");
+}
+
+#[test]
+fn multiple_errors_for_composed_deserializers() {
+    let json = config!("array": "-4,what");
+    let errors = test_deserialize::<ConfigWithComplexTypes>(json.inner()).unwrap_err();
+    assert_eq!(errors.len(), 2);
+    let err = errors.iter().find(|err| err.path() == "array.0").unwrap();
+    let inner = err.inner().to_string();
+    assert!(inner.contains("invalid value"), "{inner}");
+    let err = errors.iter().find(|err| err.path() == "array.1").unwrap();
+    let inner = err.inner().to_string();
+    assert!(inner.contains("invalid type"), "{inner}");
+
+    let json = config!("durations": r#"[5, "30us"]"#);
+    let errors = test_deserialize::<ComposedConfig>(json.inner()).unwrap_err();
+    assert_eq!(errors.len(), 2);
+    let err = errors
+        .iter()
+        .find(|err| err.path() == "durations.0")
+        .unwrap();
+    let inner = err.inner().to_string();
+    assert!(inner.contains("invalid type"), "{inner}");
+    let err = errors
+        .iter()
+        .find(|err| err.path() == "durations.1")
+        .unwrap();
+    let inner = err.inner().to_string();
+    assert!(
+        inner.contains("invalid value") && inner.contains("duration unit"),
+        "{inner}"
+    );
+
+    let json = config!("map_of_ints": r#"{ "what": 120 }"#);
+    let errors = test_deserialize::<ComposedConfig>(json.inner()).unwrap_err();
+    assert_eq!(errors.len(), 2);
+    assert!(errors.iter().any(|err| {
+        err.path() == "map_of_ints.what"
+            && err
+                .inner()
+                .to_string()
+                .starts_with("cannot deserialize key")
+    }));
+    assert!(errors.iter().any(|err| {
+        err.path() == "map_of_ints.what" && err.inner().to_string().starts_with("invalid type")
+    }));
 }

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -2,7 +2,7 @@
 
 use std::{any, borrow::Cow, fmt};
 
-use crate::de::ErasedDeserializer;
+use crate::de::_private::ErasedDeserializer;
 
 #[cfg(test)]
 mod tests;

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -1,8 +1,6 @@
 use std::{collections::BTreeSet, iter, marker::PhantomData, sync::Arc};
 
 pub use self::{env::Environment, json::Json, yaml::Yaml};
-#[cfg(doc)]
-use crate::metadata::BasicTypes;
 use crate::{
     de::{DeserializeContext, DeserializerOptions},
     schema::{ConfigRef, ConfigSchema},

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -491,7 +491,7 @@ fn parsing_complex_param_errors() {
     let err = testing::test::<ValueCoercingConfig>(env).unwrap_err();
     assert_eq!(err.len(), 1);
     let err = err.first();
-    assert_eq!(err.path(), "set");
+    assert_eq!(err.path(), "set.1");
     let inner = err.inner().to_string();
     assert!(inner.contains("invalid type"), "{inner}");
     assert_eq!(

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -212,6 +212,21 @@ pub(crate) struct ConfigWithComplexTypes {
     pub map_or_string: MapOrString,
 }
 
+#[derive(Debug, DescribeConfig, DeserializeConfig)]
+#[config(crate = crate)]
+pub(crate) struct ComposedConfig {
+    #[config(default)]
+    pub arrays: HashSet<[u64; 2]>,
+    #[config(default)]
+    pub durations: Vec<Duration>,
+    #[config(default, with = de::Delimited(","))]
+    pub delimited_durations: Vec<Duration>,
+    #[config(default)]
+    pub map_of_sizes: HashMap<String, ByteSize>,
+    #[config(default)]
+    pub map_of_ints: HashMap<u64, Duration>,
+}
+
 pub(crate) fn wrap_into_value(env: Environment) -> WithOrigin {
     let ConfigContents::KeyValue(map) = env.into_contents() else {
         unreachable!();


### PR DESCRIPTION
# What ❔

Implements a consistent deserializer for collections instead of using `Serde`.

## Why ❔

`serde`-based deserialization can lead to unexpected errors / results.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.