### PR TITLE
feat: Add missing features for Era (pt. 2)

### DIFF
--- a/crates/smart-config-commands/examples/cli.rs
+++ b/crates/smart-config-commands/examples/cli.rs
@@ -192,7 +192,7 @@ fn main() {
     let cli = Cli::parse();
 
     let mut schema = ConfigSchema::default();
-    schema.insert::<TestConfig>("test").unwrap();
+    schema.insert(&TestConfig::DESCRIPTION, "test").unwrap();
 
     match cli {
         Cli::Print { filter } => {

--- a/crates/smart-config-commands/examples/cli.rs
+++ b/crates/smart-config-commands/examples/cli.rs
@@ -43,7 +43,7 @@ pub struct TestConfig {
     pub cache_size: ByteSize,
     #[config(nest)]
     pub nested: NestedConfig,
-    #[config(nest)]
+    #[config(nest, alias = "funds")]
     pub funding: Option<FundingConfig>,
 }
 
@@ -96,7 +96,7 @@ pub struct FundingConfig {
     /// Secret string value.
     pub api_key: Option<SecretString>,
     /// Secret key.
-    #[config(secret, with = de::Serde![str])]
+    #[config(secret, with = de::Optional(de::Serde![str]))]
     pub secret_key: Option<SecretKey>,
 }
 
@@ -143,9 +143,9 @@ fn create_mock_repo(schema: &ConfigSchema, bogus: bool) -> ConfigRepository<'_> 
             ("APP_TEST_APP_NAME", "test"),
             ("APP_TEST_DIRS", "/usr/bin:usr/local/bin"),
             ("APP_TEST_CACHE_SIZE", "128 MiB"),
-            ("APP_TEST_FUNDING_API_KEY", "correct horse battery staple"),
+            ("APP_TEST_FUNDS_API_KEY", "correct horse battery staple"),
             (
-                "APP_TEST_FUNDING_SECRET_KEY",
+                "APP_TEST_FUNDS_SECRET_KEY",
                 "0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f",
             ),
         ],

--- a/crates/smart-config-commands/examples/debug.svg
+++ b/crates/smart-config-commands/examples/debug.svg
@@ -49,40 +49,40 @@
 </tspan><tspan xml:space="preserve" x="42" y="68" class="output-bg">  <tspan class="fg5">███</tspan></tspan><tspan xml:space="preserve" x="42" y="68" class="output">- <tspan class="bg5">env</tspan>, 5 param(s)
 </tspan><tspan xml:space="preserve" x="42" y="86" class="output">
 </tspan><tspan xml:space="preserve" x="42" y="104" class="output"><tspan class="bold">Values:</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="122" class="output">test.nested.exit_on_error = <tspan class="fg3">false</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="140" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="140" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.nested.exit_on_error
-</tspan><tspan xml:space="preserve" x="42" y="158" class="output">test.nested.complex = {
-</tspan><tspan xml:space="preserve" x="42" y="176" class="output">  <tspan class="bold">"array"</tspan>: [
-</tspan><tspan xml:space="preserve" x="42" y="194" class="output">    <tspan class="fg2">1</tspan>,
-</tspan><tspan xml:space="preserve" x="42" y="212" class="output">    <tspan class="fg2">2</tspan>,
-</tspan><tspan xml:space="preserve" x="42" y="230" class="output">  ],
-</tspan><tspan xml:space="preserve" x="42" y="248" class="output">  <tspan class="bold">"map"</tspan>: {
-</tspan><tspan xml:space="preserve" x="42" y="266" class="output">    <tspan class="bold">"value"</tspan>: <tspan class="fg2">25</tspan>,
-</tspan><tspan xml:space="preserve" x="42" y="284" class="output">  },
-</tspan><tspan xml:space="preserve" x="42" y="302" class="output">}
-</tspan><tspan xml:space="preserve" x="42" y="320" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="320" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.nested.complex
-</tspan><tspan xml:space="preserve" x="42" y="338" class="output">test.funding.address = <tspan class="fg6">"0x0000000000000000000000000000000000001234"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="356" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="356" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.address
-</tspan><tspan xml:space="preserve" x="42" y="374" class="output">test.funding.balance = <tspan class="fg6">"0x123456"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="392" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="392" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.balance
-</tspan><tspan xml:space="preserve" x="42" y="410" class="output-bg">                       <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="410" class="output">test.funding.api_key = <tspan class="bg6">[REDACTED]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="428" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="428" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_FUNDING_API_KEY"
-</tspan><tspan xml:space="preserve" x="42" y="446" class="output-bg">                          <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="446" class="output">test.funding.secret_key = <tspan class="bg6">[REDACTED]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="464" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="464" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_FUNDING_SECRET_KEY"
-</tspan><tspan xml:space="preserve" x="42" y="482" class="output">test.port = <tspan class="fg2">3000</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="500" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="500" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.port
-</tspan><tspan xml:space="preserve" x="42" y="518" class="output">test.app_name = <tspan class="fg6">"test"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="536" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="536" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_APP_NAME"
-</tspan><tspan xml:space="preserve" x="42" y="554" class="output">test.poll_latency = {
-</tspan><tspan xml:space="preserve" x="42" y="572" class="output">  <tspan class="bold">"ms"</tspan>: <tspan class="fg2">300</tspan>,
-</tspan><tspan xml:space="preserve" x="42" y="590" class="output">}
-</tspan><tspan xml:space="preserve" x="42" y="608" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="608" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test <tspan class="bold">-&gt;</tspan> nesting for object param 'poll_latency'
-</tspan><tspan xml:space="preserve" x="42" y="626" class="output">test.scaling_factor = <tspan class="fg2">4.2</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="644" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="644" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.scaling_factor
-</tspan><tspan xml:space="preserve" x="42" y="662" class="output">test.dir_paths = <tspan class="fg6">"/usr/bin:usr/local/bin"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="680" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="680" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_DIRS"
-</tspan><tspan xml:space="preserve" x="42" y="698" class="output">test.cache_size = <tspan class="fg6">"128 MiB"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="716" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="716" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_CACHE_SIZE"
+</tspan><tspan xml:space="preserve" x="42" y="122" class="output">test.port = <tspan class="fg2">3000</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="140" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="140" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.port
+</tspan><tspan xml:space="preserve" x="42" y="158" class="output">test.app_name = <tspan class="fg6">"test"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="176" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="176" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_APP_NAME"
+</tspan><tspan xml:space="preserve" x="42" y="194" class="output">test.poll_latency = {
+</tspan><tspan xml:space="preserve" x="42" y="212" class="output">  <tspan class="bold">"ms"</tspan>: <tspan class="fg2">300</tspan>,
+</tspan><tspan xml:space="preserve" x="42" y="230" class="output">}
+</tspan><tspan xml:space="preserve" x="42" y="248" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="248" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test <tspan class="bold">-&gt;</tspan> nesting for object param 'poll_latency'
+</tspan><tspan xml:space="preserve" x="42" y="266" class="output">test.scaling_factor = <tspan class="fg2">4.2</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="284" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="284" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.scaling_factor
+</tspan><tspan xml:space="preserve" x="42" y="302" class="output">test.dir_paths = <tspan class="fg6">"/usr/bin:usr/local/bin"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="320" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="320" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_DIRS"
+</tspan><tspan xml:space="preserve" x="42" y="338" class="output">test.cache_size = <tspan class="fg6">"128 MiB"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="356" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="356" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_CACHE_SIZE"
+</tspan><tspan xml:space="preserve" x="42" y="374" class="output">test.funding.address = <tspan class="fg6">"0x0000000000000000000000000000000000001234"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="392" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="392" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.address
+</tspan><tspan xml:space="preserve" x="42" y="410" class="output">test.funding.balance = <tspan class="fg6">"0x123456"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="428" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="428" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.balance
+</tspan><tspan xml:space="preserve" x="42" y="446" class="output-bg">                       <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="446" class="output">test.funding.api_key = <tspan class="bg6">[REDACTED]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="464" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="464" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_FUNDS_API_KEY"
+</tspan><tspan xml:space="preserve" x="42" y="482" class="output-bg">                          <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="482" class="output">test.funding.secret_key = <tspan class="bg6">[REDACTED]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="500" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="500" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_FUNDS_SECRET_KEY"
+</tspan><tspan xml:space="preserve" x="42" y="518" class="output">test.nested.exit_on_error = <tspan class="fg3">false</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="536" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="536" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.nested.exit_on_error
+</tspan><tspan xml:space="preserve" x="42" y="554" class="output">test.nested.complex = {
+</tspan><tspan xml:space="preserve" x="42" y="572" class="output">  <tspan class="bold">"array"</tspan>: [
+</tspan><tspan xml:space="preserve" x="42" y="590" class="output">    <tspan class="fg2">1</tspan>,
+</tspan><tspan xml:space="preserve" x="42" y="608" class="output">    <tspan class="fg2">2</tspan>,
+</tspan><tspan xml:space="preserve" x="42" y="626" class="output">  ],
+</tspan><tspan xml:space="preserve" x="42" y="644" class="output">  <tspan class="bold">"map"</tspan>: {
+</tspan><tspan xml:space="preserve" x="42" y="662" class="output">    <tspan class="bold">"value"</tspan>: <tspan class="fg2">25</tspan>,
+</tspan><tspan xml:space="preserve" x="42" y="680" class="output">  },
+</tspan><tspan xml:space="preserve" x="42" y="698" class="output">}
+</tspan><tspan xml:space="preserve" x="42" y="716" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="716" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.nested.complex
 </tspan></text>
     </svg>
   <rect class="scrollbar" x="853" y="10" width="5" height="40">

--- a/crates/smart-config-commands/examples/errors.svg
+++ b/crates/smart-config-commands/examples/errors.svg
@@ -50,55 +50,55 @@
 </tspan><tspan xml:space="preserve" x="42" y="86" class="output-bg">  <tspan class="fg5">███</tspan></tspan><tspan xml:space="preserve" x="42" y="86" class="output">- <tspan class="bg5">env</tspan>, 5 param(s)
 </tspan><tspan xml:space="preserve" x="42" y="104" class="output">
 </tspan><tspan xml:space="preserve" x="42" y="122" class="output"><tspan class="bold">Values:</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="140" class="output">test.nested.exit_on_error = <tspan class="fg3">false</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="158" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="158" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.nested.exit_on_error
-</tspan><tspan xml:space="preserve" x="42" y="176" class="output">test.nested.complex = <tspan class="fg6">"{ \"array\": [1, true] }"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="194" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="194" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_COMPLEX"
-</tspan><tspan xml:space="preserve" x="42" y="212" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="212" class="output">  <tspan class="bold bg1">Error:</tspan> invalid type: boolean `true`, expected u32 number
-</tspan><tspan xml:space="preserve" x="42" y="230" class="output">    at <tspan class="bold">test.nested.complex</tspan>, NestedConfig.complex
-</tspan><tspan xml:space="preserve" x="42" y="248" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="248" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_COMPLEX" <tspan class="bold">-&gt;</tspan> parsed JSON string <tspan class="bold">-&gt;</tspan> .array.1
-</tspan><tspan xml:space="preserve" x="42" y="266" class="output">test.nested.more_timeouts = <tspan class="fg6">"nope,124us"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="284" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="284" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_TIMEOUTS"
-</tspan><tspan xml:space="preserve" x="42" y="302" class="output-bg">  <tspan class="fg1">███████</tspan></tspan><tspan xml:space="preserve" x="42" y="302" class="output">  <tspan class="bold bg1">Errors:</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="320" class="output">  - invalid type: string "nope", expected value with unit, like '10 ms'
-</tspan><tspan xml:space="preserve" x="42" y="338" class="output">    at <tspan class="bold">test.nested.more_timeouts.0</tspan>, NestedConfig.more_timeouts
-</tspan><tspan xml:space="preserve" x="42" y="356" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="356" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_TIMEOUTS" <tspan class="bold">-&gt;</tspan> ","-delimited string <tspan class="bold">-&gt;</tspan> .0
-</tspan><tspan xml:space="preserve" x="42" y="374" class="output">  - invalid value: string "us", expected duration unit, like 'ms', up to 'days'
-</tspan><tspan xml:space="preserve" x="42" y="392" class="output">    at <tspan class="bold">test.nested.more_timeouts.1</tspan>, NestedConfig.more_timeouts
-</tspan><tspan xml:space="preserve" x="42" y="410" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="410" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_TIMEOUTS" <tspan class="bold">-&gt;</tspan> ","-delimited string <tspan class="bold">-&gt;</tspan> .1
-</tspan><tspan xml:space="preserve" x="42" y="428" class="output">test.port = <tspan class="fg2">3000</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="446" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="446" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.port
-</tspan><tspan xml:space="preserve" x="42" y="464" class="output">test.app_name = <tspan class="fg6">"test"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="482" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="482" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_APP_NAME"
-</tspan><tspan xml:space="preserve" x="42" y="500" class="output">test.poll_latency = {
-</tspan><tspan xml:space="preserve" x="42" y="518" class="output">  <tspan class="bold">"ms"</tspan>: <tspan class="fg2">300</tspan>,
-</tspan><tspan xml:space="preserve" x="42" y="536" class="output">}
-</tspan><tspan xml:space="preserve" x="42" y="554" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="554" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test <tspan class="bold">-&gt;</tspan> nesting for object param 'poll_latency'
-</tspan><tspan xml:space="preserve" x="42" y="572" class="output">test.scaling_factor = <tspan class="fg2">4.2</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="590" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="590" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.scaling_factor
-</tspan><tspan xml:space="preserve" x="42" y="608" class="output">test.dir_paths = <tspan class="fg6">"/usr/bin:usr/local/bin"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="626" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="626" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_DIRS"
-</tspan><tspan xml:space="preserve" x="42" y="644" class="output">test.timeout_sec = <tspan class="fg6">"what?"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="662" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="662" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_TIMEOUT_SEC"
-</tspan><tspan xml:space="preserve" x="42" y="680" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="680" class="output">  <tspan class="bold bg1">Error:</tspan> invalid digit found in string while parsing u64 value 'what?'
-</tspan><tspan xml:space="preserve" x="42" y="698" class="output">    at <tspan class="bold">test.timeout_sec</tspan>, TestConfig.timeout_sec
-</tspan><tspan xml:space="preserve" x="42" y="716" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="716" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_TIMEOUT_SEC"
-</tspan><tspan xml:space="preserve" x="42" y="734" class="output">test.cache_size = <tspan class="fg6">"128 MiBis"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="752" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="752" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_CACHE_SIZE"
-</tspan><tspan xml:space="preserve" x="42" y="770" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="770" class="output">  <tspan class="bold bg1">Error:</tspan> invalid value: string "MiBis", expected duration unit, like 'KB', up to 'GB'
-</tspan><tspan xml:space="preserve" x="42" y="788" class="output">    at <tspan class="bold">test.cache_size</tspan>, TestConfig.cache_size
-</tspan><tspan xml:space="preserve" x="42" y="806" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="806" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_CACHE_SIZE"
-</tspan><tspan xml:space="preserve" x="42" y="824" class="output">test.funding.address = <tspan class="fg6">"0x0000000000000000000000000000000000001234"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="842" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="842" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.address
-</tspan><tspan xml:space="preserve" x="42" y="860" class="output">test.funding.balance = <tspan class="fg6">"0x123456"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="878" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="878" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.balance
-</tspan><tspan xml:space="preserve" x="42" y="896" class="output-bg">                       <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="896" class="output">test.funding.api_key = <tspan class="bg6">[REDACTED]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="914" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="914" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_FUNDING_API_KEY"
-</tspan><tspan xml:space="preserve" x="42" y="932" class="output-bg">                          <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="932" class="output">test.funding.secret_key = <tspan class="bg6">[REDACTED]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="950" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="950" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_FUNDING_SECRET_KEY"
-</tspan><tspan xml:space="preserve" x="42" y="968" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="968" class="output">  <tspan class="bold bg1">Error:</tspan> invalid length 9, expected a (both 0x-prefixed or not) hex string or byte array containing 32 bytes
-</tspan><tspan xml:space="preserve" x="42" y="986" class="output">    at <tspan class="bold">test.funding.secret_key</tspan>, FundingConfig.secret_key
-</tspan><tspan xml:space="preserve" x="42" y="1004" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="1004" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_FUNDING_SECRET_KEY"
+</tspan><tspan xml:space="preserve" x="42" y="140" class="output">test.port = <tspan class="fg2">3000</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="158" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="158" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.port
+</tspan><tspan xml:space="preserve" x="42" y="176" class="output">test.app_name = <tspan class="fg6">"test"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="194" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="194" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_APP_NAME"
+</tspan><tspan xml:space="preserve" x="42" y="212" class="output">test.poll_latency = {
+</tspan><tspan xml:space="preserve" x="42" y="230" class="output">  <tspan class="bold">"ms"</tspan>: <tspan class="fg2">300</tspan>,
+</tspan><tspan xml:space="preserve" x="42" y="248" class="output">}
+</tspan><tspan xml:space="preserve" x="42" y="266" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="266" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test <tspan class="bold">-&gt;</tspan> nesting for object param 'poll_latency'
+</tspan><tspan xml:space="preserve" x="42" y="284" class="output">test.scaling_factor = <tspan class="fg2">4.2</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="302" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="302" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.scaling_factor
+</tspan><tspan xml:space="preserve" x="42" y="320" class="output">test.dir_paths = <tspan class="fg6">"/usr/bin:usr/local/bin"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="338" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="338" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_DIRS"
+</tspan><tspan xml:space="preserve" x="42" y="356" class="output">test.timeout_sec = <tspan class="fg6">"what?"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="374" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="374" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_TIMEOUT_SEC"
+</tspan><tspan xml:space="preserve" x="42" y="392" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="392" class="output">  <tspan class="bold bg1">Error:</tspan> invalid digit found in string while parsing u64 value 'what?'
+</tspan><tspan xml:space="preserve" x="42" y="410" class="output">    at <tspan class="bold">test.timeout_sec</tspan>, TestConfig.timeout_sec
+</tspan><tspan xml:space="preserve" x="42" y="428" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="428" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_TIMEOUT_SEC"
+</tspan><tspan xml:space="preserve" x="42" y="446" class="output">test.cache_size = <tspan class="fg6">"128 MiBis"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="464" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="464" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_CACHE_SIZE"
+</tspan><tspan xml:space="preserve" x="42" y="482" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="482" class="output">  <tspan class="bold bg1">Error:</tspan> invalid value: string "MiBis", expected duration unit, like 'KB', up to 'GB'
+</tspan><tspan xml:space="preserve" x="42" y="500" class="output">    at <tspan class="bold">test.cache_size</tspan>, TestConfig.cache_size
+</tspan><tspan xml:space="preserve" x="42" y="518" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="518" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_CACHE_SIZE"
+</tspan><tspan xml:space="preserve" x="42" y="536" class="output">test.funding.address = <tspan class="fg6">"0x0000000000000000000000000000000000001234"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="554" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="554" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.address
+</tspan><tspan xml:space="preserve" x="42" y="572" class="output">test.funding.balance = <tspan class="fg6">"0x123456"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="590" class="output-bg">          <tspan class="fg2">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="590" class="output">  Origin: <tspan class="bg2">YAML:</tspan>/config/test.yml <tspan class="bold">-&gt;</tspan> .test.funding.balance
+</tspan><tspan xml:space="preserve" x="42" y="608" class="output-bg">                       <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="608" class="output">test.funding.api_key = <tspan class="bg6">[REDACTED]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="626" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="626" class="output">  Origin: <tspan class="bg5">env:</tspan>"APP_TEST_FUNDS_API_KEY"
+</tspan><tspan xml:space="preserve" x="42" y="644" class="output-bg">                          <tspan class="fg6">██████████</tspan></tspan><tspan xml:space="preserve" x="42" y="644" class="output">test.funding.secret_key = <tspan class="bg6">[REDACTED]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="662" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="662" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_FUNDING_SECRET_KEY"
+</tspan><tspan xml:space="preserve" x="42" y="680" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="680" class="output">  <tspan class="bold bg1">Error:</tspan> invalid length 9, expected a (both 0x-prefixed or not) hex string or byte array containing 32 bytes
+</tspan><tspan xml:space="preserve" x="42" y="698" class="output">    at <tspan class="bold">test.funding.secret_key</tspan>, FundingConfig.secret_key
+</tspan><tspan xml:space="preserve" x="42" y="716" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="716" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_FUNDING_SECRET_KEY"
+</tspan><tspan xml:space="preserve" x="42" y="734" class="output">test.nested.exit_on_error = <tspan class="fg3">false</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="752" class="output-bg">          <tspan class="fg6">█████</tspan></tspan><tspan xml:space="preserve" x="42" y="752" class="output">  Origin: <tspan class="bg6">JSON:</tspan>/config/base.json <tspan class="bold">-&gt;</tspan> .test.nested.exit_on_error
+</tspan><tspan xml:space="preserve" x="42" y="770" class="output">test.nested.complex = <tspan class="fg6">"{ \"array\": [1, true] }"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="788" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="788" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_COMPLEX"
+</tspan><tspan xml:space="preserve" x="42" y="806" class="output-bg">  <tspan class="fg1">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="806" class="output">  <tspan class="bold bg1">Error:</tspan> invalid type: boolean `true`, expected u32 number
+</tspan><tspan xml:space="preserve" x="42" y="824" class="output">    at <tspan class="bold">test.nested.complex</tspan>, NestedConfig.complex
+</tspan><tspan xml:space="preserve" x="42" y="842" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="842" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_COMPLEX" <tspan class="bold">-&gt;</tspan> parsed JSON string <tspan class="bold">-&gt;</tspan> .array.1
+</tspan><tspan xml:space="preserve" x="42" y="860" class="output">test.nested.more_timeouts = <tspan class="fg6">"nope,124us"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="878" class="output-bg">          <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="878" class="output">  Origin: <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_TIMEOUTS"
+</tspan><tspan xml:space="preserve" x="42" y="896" class="output-bg">  <tspan class="fg1">███████</tspan></tspan><tspan xml:space="preserve" x="42" y="896" class="output">  <tspan class="bold bg1">Errors:</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="914" class="output">  - invalid type: string "nope", expected value with unit, like '10 ms'
+</tspan><tspan xml:space="preserve" x="42" y="932" class="output">    at <tspan class="bold">test.nested.more_timeouts.0</tspan>, NestedConfig.more_timeouts
+</tspan><tspan xml:space="preserve" x="42" y="950" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="950" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_TIMEOUTS" <tspan class="bold">-&gt;</tspan> ","-delimited string <tspan class="bold">-&gt;</tspan> .0
+</tspan><tspan xml:space="preserve" x="42" y="968" class="output">  - invalid value: string "us", expected duration unit, like 'ms', up to 'days'
+</tspan><tspan xml:space="preserve" x="42" y="986" class="output">    at <tspan class="bold">test.nested.more_timeouts.1</tspan>, NestedConfig.more_timeouts
+</tspan><tspan xml:space="preserve" x="42" y="1004" class="output-bg">    <tspan class="fg5">████</tspan></tspan><tspan xml:space="preserve" x="42" y="1004" class="output">    <tspan class="bg5">env:</tspan>"BOGUS_TEST_NESTED_TIMEOUTS" <tspan class="bold">-&gt;</tspan> ","-delimited string <tspan class="bold">-&gt;</tspan> .1
 </tspan></text>
     </svg>
   <rect class="scrollbar" x="853" y="10" width="5" height="40">

--- a/crates/smart-config-commands/examples/help.svg
+++ b/crates/smart-config-commands/examples/help.svg
@@ -40,80 +40,84 @@
   <circle cx="37" cy="-9" r="7" style="fill: #ffc706;"/>
   <circle cx="57" cy="-9" r="7" style="fill: #38b54a;"/>
     <svg x="0" y="10" width="860" height="540" viewBox="0 0 860 540">
-      <animate attributeName="viewBox" values="0 0 860 540;0 72 860 540;0 144 860 540;0 216 860 540;0 288 860 540;0 360 860 540;0 432 860 540;0 504 860 540;0 576 860 540;0 648 860 540;0 720 860 540" dur="40.0s" repeatCount="indefinite" calcMode="discrete" />
+      <animate attributeName="viewBox" values="0 0 860 540;0 72 860 540;0 144 860 540;0 216 860 540;0 288 860 540;0 360 860 540;0 432 860 540;0 504 860 540;0 576 860 540;0 648 860 540;0 720 860 540;0 792 860 540" dur="44.0s" repeatCount="indefinite" calcMode="discrete" />
       <g class="input-bg"></g>
-      <text class="container fg7 line-numbers"><tspan x="34" y="14">1</tspan><tspan x="34" y="32">2</tspan><tspan x="34" y="50">3</tspan><tspan x="34" y="68">4</tspan><tspan x="34" y="86">5</tspan><tspan x="34" y="104">6</tspan><tspan x="34" y="122">7</tspan><tspan x="34" y="140">8</tspan><tspan x="34" y="158">9</tspan><tspan x="34" y="176">10</tspan><tspan x="34" y="194">11</tspan><tspan x="34" y="212">12</tspan><tspan x="34" y="230">13</tspan><tspan x="34" y="248">14</tspan><tspan x="34" y="266">15</tspan><tspan x="34" y="284">16</tspan><tspan x="34" y="302">17</tspan><tspan x="34" y="320">18</tspan><tspan x="34" y="338">19</tspan><tspan x="34" y="356">20</tspan><tspan x="34" y="374">21</tspan><tspan x="34" y="392">22</tspan><tspan x="34" y="410">23</tspan><tspan x="34" y="428">24</tspan><tspan x="34" y="446">25</tspan><tspan x="34" y="464">26</tspan><tspan x="34" y="482">27</tspan><tspan x="34" y="500">28</tspan><tspan x="34" y="518">29</tspan><tspan x="34" y="536">30</tspan><tspan x="34" y="554">31</tspan><tspan x="34" y="572">32</tspan><tspan x="34" y="590">33</tspan><tspan x="34" y="608">34</tspan><tspan x="34" y="626">35</tspan><tspan x="34" y="644">36</tspan><tspan x="34" y="662">37</tspan><tspan x="34" y="680">38</tspan><tspan x="34" y="698">39</tspan><tspan x="34" y="716">40</tspan><tspan x="34" y="734">41</tspan><tspan x="34" y="752">42</tspan><tspan x="34" y="770">43</tspan><tspan x="34" y="788">44</tspan><tspan x="34" y="806">45</tspan><tspan x="34" y="824">46</tspan><tspan x="34" y="842">47</tspan><tspan x="34" y="860">48</tspan><tspan x="34" y="878">49</tspan><tspan x="34" y="896">50</tspan><tspan x="34" y="914">51</tspan><tspan x="34" y="932">52</tspan><tspan x="34" y="950">53</tspan><tspan x="34" y="968">54</tspan><tspan x="34" y="986">55</tspan><tspan x="34" y="1004">56</tspan><tspan x="34" y="1022">57</tspan><tspan x="34" y="1040">58</tspan><tspan x="34" y="1058">59</tspan><tspan x="34" y="1076">60</tspan><tspan x="34" y="1094">61</tspan><tspan x="34" y="1112">62</tspan><tspan x="34" y="1130">63</tspan><tspan x="34" y="1148">64</tspan><tspan x="34" y="1166">65</tspan><tspan x="34" y="1184">66</tspan><tspan x="34" y="1202">67</tspan><tspan x="34" y="1220">68</tspan></text>
-      <text class="container fg7"><tspan xml:space="preserve" x="42" y="14" class="output"><tspan class="dimmed">test.nested.</tspan><tspan class="bold">exit_on_error</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="32" class="output">  <tspan class="underline">Type</tspan>: Boolean <tspan class="dimmed">[Rust: bool]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="50" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">true</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="68" class="output">  Whether to exit the application on error.
-</tspan><tspan xml:space="preserve" x="42" y="86" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="104" class="output"><tspan class="dimmed">test.nested.</tspan><tspan class="bold">complex</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="122" class="output">  <tspan class="underline">Type</tspan>: object <tspan class="dimmed">[Rust: ComplexParam]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="140" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">ComplexParam { array: [], map: {} }</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="158" class="output">  Complex parameter deserialized from an object.
-</tspan><tspan xml:space="preserve" x="42" y="176" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="194" class="output"><tspan class="dimmed">test.nested.</tspan><tspan class="bold">more_timeouts</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="212" class="output"><tspan class="dimmed">test.nested.</tspan>timeouts
-</tspan><tspan xml:space="preserve" x="42" y="230" class="output">  <tspan class="underline">Type</tspan>: string | array <tspan class="dimmed">[Rust: Vec]</tspan>; using "," delimiter
-</tspan><tspan xml:space="preserve" x="42" y="248" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">[]</tspan>
+      <text class="container fg7 line-numbers"><tspan x="34" y="14">1</tspan><tspan x="34" y="32">2</tspan><tspan x="34" y="50">3</tspan><tspan x="34" y="68">4</tspan><tspan x="34" y="86">5</tspan><tspan x="34" y="104">6</tspan><tspan x="34" y="122">7</tspan><tspan x="34" y="140">8</tspan><tspan x="34" y="158">9</tspan><tspan x="34" y="176">10</tspan><tspan x="34" y="194">11</tspan><tspan x="34" y="212">12</tspan><tspan x="34" y="230">13</tspan><tspan x="34" y="248">14</tspan><tspan x="34" y="266">15</tspan><tspan x="34" y="284">16</tspan><tspan x="34" y="302">17</tspan><tspan x="34" y="320">18</tspan><tspan x="34" y="338">19</tspan><tspan x="34" y="356">20</tspan><tspan x="34" y="374">21</tspan><tspan x="34" y="392">22</tspan><tspan x="34" y="410">23</tspan><tspan x="34" y="428">24</tspan><tspan x="34" y="446">25</tspan><tspan x="34" y="464">26</tspan><tspan x="34" y="482">27</tspan><tspan x="34" y="500">28</tspan><tspan x="34" y="518">29</tspan><tspan x="34" y="536">30</tspan><tspan x="34" y="554">31</tspan><tspan x="34" y="572">32</tspan><tspan x="34" y="590">33</tspan><tspan x="34" y="608">34</tspan><tspan x="34" y="626">35</tspan><tspan x="34" y="644">36</tspan><tspan x="34" y="662">37</tspan><tspan x="34" y="680">38</tspan><tspan x="34" y="698">39</tspan><tspan x="34" y="716">40</tspan><tspan x="34" y="734">41</tspan><tspan x="34" y="752">42</tspan><tspan x="34" y="770">43</tspan><tspan x="34" y="788">44</tspan><tspan x="34" y="806">45</tspan><tspan x="34" y="824">46</tspan><tspan x="34" y="842">47</tspan><tspan x="34" y="860">48</tspan><tspan x="34" y="878">49</tspan><tspan x="34" y="896">50</tspan><tspan x="34" y="914">51</tspan><tspan x="34" y="932">52</tspan><tspan x="34" y="950">53</tspan><tspan x="34" y="968">54</tspan><tspan x="34" y="986">55</tspan><tspan x="34" y="1004">56</tspan><tspan x="34" y="1022">57</tspan><tspan x="34" y="1040">58</tspan><tspan x="34" y="1058">59</tspan><tspan x="34" y="1076">60</tspan><tspan x="34" y="1094">61</tspan><tspan x="34" y="1112">62</tspan><tspan x="34" y="1130">63</tspan><tspan x="34" y="1148">64</tspan><tspan x="34" y="1166">65</tspan><tspan x="34" y="1184">66</tspan><tspan x="34" y="1202">67</tspan><tspan x="34" y="1220">68</tspan><tspan x="34" y="1238">69</tspan><tspan x="34" y="1256">70</tspan><tspan x="34" y="1274">71</tspan><tspan x="34" y="1292">72</tspan></text>
+      <text class="container fg7"><tspan xml:space="preserve" x="42" y="14" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">port</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="32" class="output"><tspan class="dimmed">test.</tspan>bind_to
+</tspan><tspan xml:space="preserve" x="42" y="50" class="output">  <tspan class="underline">Type</tspan>: integer <tspan class="dimmed">[Rust: u16]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="68" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">8080</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="86" class="output">  Port to bind to.
+</tspan><tspan xml:space="preserve" x="42" y="104" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="122" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">app_name</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="140" class="output">  <tspan class="underline">Type</tspan>: string <tspan class="dimmed">[Rust: String]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="158" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">"app"</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="176" class="output">  Application name.
+</tspan><tspan xml:space="preserve" x="42" y="194" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="212" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">poll_latency</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="230" class="output">  <tspan class="underline">Type</tspan>: string | object <tspan class="dimmed">[Rust: Duration]</tspan>; duration with unit, or object with single unit key
+</tspan><tspan xml:space="preserve" x="42" y="248" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">500ms</tspan>
 </tspan><tspan xml:space="preserve" x="42" y="266" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="284" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">port</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="302" class="output"><tspan class="dimmed">test.</tspan>bind_to
-</tspan><tspan xml:space="preserve" x="42" y="320" class="output">  <tspan class="underline">Type</tspan>: integer <tspan class="dimmed">[Rust: u16]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="338" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">8080</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="356" class="output">  Port to bind to.
-</tspan><tspan xml:space="preserve" x="42" y="374" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="392" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">app_name</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="410" class="output">  <tspan class="underline">Type</tspan>: string <tspan class="dimmed">[Rust: String]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="428" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">"app"</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="446" class="output">  Application name.
+</tspan><tspan xml:space="preserve" x="42" y="284" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">scaling_factor</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="302" class="output">  <tspan class="underline">Type</tspan>: integer | float <tspan class="dimmed">[Rust: Option]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="320" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">None</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="338" class="output">  Should be greater than 0.
+</tspan><tspan xml:space="preserve" x="42" y="356" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="374" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">dir_paths</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="392" class="output"><tspan class="dimmed">test.</tspan>dirs
+</tspan><tspan xml:space="preserve" x="42" y="410" class="output">  <tspan class="underline">Type</tspan>: string | array <tspan class="dimmed">[Rust: HashSet]</tspan>; using ":" delimiter
+</tspan><tspan xml:space="preserve" x="42" y="428" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">{}</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="446" class="output">  Paths to key directories.
 </tspan><tspan xml:space="preserve" x="42" y="464" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="482" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">poll_latency</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="500" class="output">  <tspan class="underline">Type</tspan>: string | object <tspan class="dimmed">[Rust: Duration]</tspan>; duration with unit, or object with single unit key
-</tspan><tspan xml:space="preserve" x="42" y="518" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">500ms</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="536" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="554" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">scaling_factor</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="572" class="output">  <tspan class="underline">Type</tspan>: integer | float <tspan class="dimmed">[Rust: Option]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="590" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">None</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="608" class="output">  Should be greater than 0.
-</tspan><tspan xml:space="preserve" x="42" y="626" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="644" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">dir_paths</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="662" class="output"><tspan class="dimmed">test.</tspan>dirs
-</tspan><tspan xml:space="preserve" x="42" y="680" class="output">  <tspan class="underline">Type</tspan>: string | array <tspan class="dimmed">[Rust: HashSet]</tspan>; using ":" delimiter
-</tspan><tspan xml:space="preserve" x="42" y="698" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">{}</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="716" class="output">  Paths to key directories.
+</tspan><tspan xml:space="preserve" x="42" y="482" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">timeout_sec</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="500" class="output">  <tspan class="underline">Type</tspan>: integer <tspan class="dimmed">[Rust: Duration]</tspan>; time duration; unit: <tspan class="fg6">seconds</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="518" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">60s</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="536" class="output">  Timeout for some operation.
+</tspan><tspan xml:space="preserve" x="42" y="554" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="572" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">cache_size</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="590" class="output">  <tspan class="underline">Type</tspan>: string | object <tspan class="dimmed">[Rust: ByteSize]</tspan>; size with unit, or object with single unit key
+</tspan><tspan xml:space="preserve" x="42" y="608" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">16 MiB</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="626" class="output">  In-memory cache size.
+</tspan><tspan xml:space="preserve" x="42" y="644" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="662" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">address</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="680" class="output"><tspan class="dimmed">test.funds.</tspan>address
+</tspan><tspan xml:space="preserve" x="42" y="698" class="output">  <tspan class="underline">Type</tspan>: string <tspan class="dimmed">[Rust: Address]</tspan>; hex string with optional 0x prefix
+</tspan><tspan xml:space="preserve" x="42" y="716" class="output">  Ethereum-like address to fund.
 </tspan><tspan xml:space="preserve" x="42" y="734" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="752" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">timeout_sec</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="770" class="output">  <tspan class="underline">Type</tspan>: integer <tspan class="dimmed">[Rust: Duration]</tspan>; time duration; unit: <tspan class="fg6">seconds</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="788" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">60s</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="806" class="output">  Timeout for some operation.
+</tspan><tspan xml:space="preserve" x="42" y="752" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">balance</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="770" class="output"><tspan class="dimmed">test.funds.</tspan>balance
+</tspan><tspan xml:space="preserve" x="42" y="788" class="output">  <tspan class="underline">Type</tspan>: string <tspan class="dimmed">[Rust: U256]</tspan>; 0x-prefixed hex number
+</tspan><tspan xml:space="preserve" x="42" y="806" class="output">  Initial balance for the address.
 </tspan><tspan xml:space="preserve" x="42" y="824" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="842" class="output"><tspan class="dimmed">test.</tspan><tspan class="bold">cache_size</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="860" class="output">  <tspan class="underline">Type</tspan>: string | object <tspan class="dimmed">[Rust: ByteSize]</tspan>; size with unit, or object with single unit key
-</tspan><tspan xml:space="preserve" x="42" y="878" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">16 MiB</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="896" class="output">  In-memory cache size.
-</tspan><tspan xml:space="preserve" x="42" y="914" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="932" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">address</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="950" class="output">  <tspan class="underline">Type</tspan>: string <tspan class="dimmed">[Rust: Address]</tspan>; hex string with optional 0x prefix
-</tspan><tspan xml:space="preserve" x="42" y="968" class="output">  Ethereum-like address to fund.
-</tspan><tspan xml:space="preserve" x="42" y="986" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="1004" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">balance</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1022" class="output">  <tspan class="underline">Type</tspan>: string <tspan class="dimmed">[Rust: U256]</tspan>; 0x-prefixed hex number
-</tspan><tspan xml:space="preserve" x="42" y="1040" class="output">  Initial balance for the address.
-</tspan><tspan xml:space="preserve" x="42" y="1058" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="1076" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">api_key</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1094" class="output-bg">        <tspan class="fg6">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="1094" class="output">  <tspan class="underline">Type</tspan>: <tspan class="bg6">secret</tspan> string <tspan class="dimmed">[Rust: Option]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1112" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">None</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1130" class="output">  Secret string value.
-</tspan><tspan xml:space="preserve" x="42" y="1148" class="output">
-</tspan><tspan xml:space="preserve" x="42" y="1166" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">secret_key</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1184" class="output-bg">        <tspan class="fg6">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="1184" class="output">  <tspan class="underline">Type</tspan>: <tspan class="bg6">secret</tspan> string <tspan class="dimmed">[Rust: Option]</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1202" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">None</tspan>
-</tspan><tspan xml:space="preserve" x="42" y="1220" class="output">  Secret key.
+</tspan><tspan xml:space="preserve" x="42" y="842" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">api_key</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="860" class="output"><tspan class="dimmed">test.funds.</tspan>api_key
+</tspan><tspan xml:space="preserve" x="42" y="878" class="output-bg">        <tspan class="fg6">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="878" class="output">  <tspan class="underline">Type</tspan>: <tspan class="bg6">secret</tspan> string <tspan class="dimmed">[Rust: Option]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="896" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">None</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="914" class="output">  Secret string value.
+</tspan><tspan xml:space="preserve" x="42" y="932" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="950" class="output"><tspan class="dimmed">test.funding.</tspan><tspan class="bold">secret_key</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="968" class="output"><tspan class="dimmed">test.funds.</tspan>secret_key
+</tspan><tspan xml:space="preserve" x="42" y="986" class="output-bg">        <tspan class="fg6">██████</tspan></tspan><tspan xml:space="preserve" x="42" y="986" class="output">  <tspan class="underline">Type</tspan>: <tspan class="bg6">secret</tspan> string <tspan class="dimmed">[Rust: Option]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1004" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">None</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1022" class="output">  Secret key.
+</tspan><tspan xml:space="preserve" x="42" y="1040" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="1058" class="output"><tspan class="dimmed">test.nested.</tspan><tspan class="bold">exit_on_error</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1076" class="output">  <tspan class="underline">Type</tspan>: Boolean <tspan class="dimmed">[Rust: bool]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1094" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">true</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1112" class="output">  Whether to exit the application on error.
+</tspan><tspan xml:space="preserve" x="42" y="1130" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="1148" class="output"><tspan class="dimmed">test.nested.</tspan><tspan class="bold">complex</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1166" class="output">  <tspan class="underline">Type</tspan>: object <tspan class="dimmed">[Rust: ComplexParam]</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1184" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">ComplexParam { array: [], map: {} }</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1202" class="output">  Complex parameter deserialized from an object.
+</tspan><tspan xml:space="preserve" x="42" y="1220" class="output">
+</tspan><tspan xml:space="preserve" x="42" y="1238" class="output"><tspan class="dimmed">test.nested.</tspan><tspan class="bold">more_timeouts</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="1256" class="output"><tspan class="dimmed">test.nested.</tspan>timeouts
+</tspan><tspan xml:space="preserve" x="42" y="1274" class="output">  <tspan class="underline">Type</tspan>: string | array <tspan class="dimmed">[Rust: Vec]</tspan>; using "," delimiter
+</tspan><tspan xml:space="preserve" x="42" y="1292" class="output">  <tspan class="underline">Default</tspan>: <tspan class="fg2">[]</tspan>
 </tspan></text>
     </svg>
   <rect class="scrollbar" x="853" y="10" width="5" height="40">
-    <animateTransform attributeName="transform" attributeType="XML" type="translate" values="0 0;0 50;0 100;0 150;0 200;0 250;0 300;0 350;0 400;0 450;0 500" dur="40.0s" repeatCount="indefinite" calcMode="discrete" />
+    <animateTransform attributeName="transform" attributeType="XML" type="translate" values="0 0;0 45;0 90;0 136;0 181;0 227;0 272;0 318;0 363;0 409;0 454;0 500" dur="44.0s" repeatCount="indefinite" calcMode="discrete" />
   </rect>
 </svg>

--- a/crates/smart-config-derive/src/describe.rs
+++ b/crates/smart-config-derive/src/describe.rs
@@ -111,6 +111,7 @@ impl ConfigField {
     fn describe_nested_config(&self, parent: &ConfigContainer) -> proc_macro2::TokenStream {
         let cr = parent.cr(self.name_span());
         let name = &self.name;
+        let aliases = self.attrs.aliases.iter();
         let ty = Self::unwrap_option(&self.ty).unwrap_or(&self.ty);
         let config_name = if self.attrs.flatten {
             String::new()
@@ -121,6 +122,7 @@ impl ConfigField {
         quote_spanned! {self.name_span()=>
             #cr::metadata::NestedConfigMetadata {
                 name: #config_name,
+                aliases: &[#(#aliases,)*],
                 rust_field_name: ::core::stringify!(#name),
                 meta: &<#ty as #cr::DescribeConfig>::DESCRIPTION,
             }
@@ -135,6 +137,7 @@ impl ConfigContainer {
         let name_str = name.to_string();
         let help = &self.help;
 
+        // FIXME: also validate names / aliases for nested configs
         let all_fields = self.fields.all_fields();
         let params = all_fields.iter().filter_map(|field| {
             if !field.attrs.nest {

--- a/crates/smart-config-derive/src/utils.rs
+++ b/crates/smart-config-derive/src/utils.rs
@@ -198,10 +198,9 @@ impl ConfigFieldAttrs {
             let msg = "cannot make `flatten`ed config optional; did you mean to make it nested?";
             return Err(syn::Error::new(flatten_span, msg));
         }
-        if nest && !aliases.is_empty() {
-            let msg = "aliases for nested / flattened configs are not supported yet";
-            let span = flatten_span.or(nested_span).unwrap();
-            return Err(syn::Error::new(span, msg));
+        if let (Some(flatten_span), false) = (flatten_span, aliases.is_empty()) {
+            let msg = "aliases for flattened configs are not supported yet; did you mean to make a config nested?";
+            return Err(syn::Error::new(flatten_span, msg));
         }
         if let (Some(secret_span), true) = (secret_span, nest) {
             let msg = "only params can be marked as secret, sub-configs cannot";

--- a/crates/smart-config/README.md
+++ b/crates/smart-config/README.md
@@ -152,7 +152,7 @@ pub struct TestConfig {
 }
 
 let mut schema = ConfigSchema::default();
-schema.insert::<TestConfig>("test");
+schema.insert(&TestConfig::DESCRIPTION, "test");
 // Assume we use two config sources: a YAML file and env vars,
 // the latter having higher priority.
 let yaml = r"

--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -15,12 +15,13 @@ use crate::{
     error::ErrorWithOrigin,
     value::{Map, StrValue, Value, ValueOrigin, WithOrigin},
 };
+use crate::utils::EnumVariant;
 
 /// Available deserialization options.
 #[derive(Debug, Clone, Default)]
 pub struct DeserializerOptions {
-    /// Enables coercion of variant names from `SHOUTING_CASE` to `shouting_case`.
-    pub coerce_shouting_variant_names: bool,
+    /// Enables coercion of variant names between cases, e.g. from `SHOUTING_CASE` to `shouting_case`.
+    pub coerce_variant_names: bool,
 }
 
 impl WithOrigin {
@@ -232,14 +233,11 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'_> {
             _ => return Err(self.invalid_type("string or object with single key")),
         };
 
-        if self.options.coerce_shouting_variant_names && variant.chars().any(char::is_uppercase) {
-            let lc_variant = variant.to_lowercase();
-            let expected_variant = variants
-                .iter()
-                .copied()
-                .find(|&expected| expected == lc_variant);
-            if let Some(expected_variant) = expected_variant {
-                variant = expected_variant;
+        if self.options.coerce_variant_names {
+            if let Some(parsed) = EnumVariant::new(variant) {
+                if let Some(expected_variant) = parsed.try_match(variants) {
+                    variant = expected_variant;
+                }
             }
         }
 

--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -13,9 +13,9 @@ use serde::{
 
 use crate::{
     error::ErrorWithOrigin,
+    utils::EnumVariant,
     value::{Map, StrValue, Value, ValueOrigin, WithOrigin},
 };
-use crate::utils::EnumVariant;
 
 /// Available deserialization options.
 #[derive(Debug, Clone, Default)]

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -61,7 +61,7 @@ fn parsing_param() {
     assert_eq!(path, "repeated.0");
     extract_json_name(source);
 
-    options.coerce_shouting_variant_names = true;
+    options.coerce_variant_names = true;
     let deserializer = ValueDeserializer::new(json.inner(), &options);
     let config = TestParam::deserialize(deserializer).unwrap();
     assert_eq!(config.int, 42);

--- a/crates/smart-config/src/de/units.rs
+++ b/crates/smart-config/src/de/units.rs
@@ -191,13 +191,13 @@ pub struct WithUnit;
 enum RawDuration {
     #[serde(alias = "ms", alias = "milliseconds")]
     Millis(u64),
-    #[serde(alias = "sec", alias = "secs")]
+    #[serde(alias = "second", alias = "s", alias = "sec", alias = "secs")]
     Seconds(u64),
-    #[serde(alias = "min", alias = "mins")]
+    #[serde(alias = "minute", alias = "min", alias = "mins")]
     Minutes(u64),
-    #[serde(alias = "hr")]
+    #[serde(alias = "hour", alias = "hr")]
     Hours(u64),
-    #[serde(alias = "d")]
+    #[serde(alias = "day", alias = "d")]
     Days(u64),
 }
 
@@ -219,11 +219,11 @@ impl FromStr for RawDuration {
         let value: u64 = s[..unit_start].parse().map_err(DeError::custom)?;
         let unit = s[unit_start..].trim();
         Ok(match unit {
-            "millis" | "ms" | "milliseconds" => Self::Millis(value),
-            "seconds" | "sec" | "secs" => Self::Seconds(value),
-            "minutes" | "min" | "mins" => Self::Minutes(value),
-            "hours" | "hr" => Self::Hours(value),
-            "days" | "d" => Self::Days(value),
+            "milliseconds" | "millis" | "ms" => Self::Millis(value),
+            "seconds" | "second" | "secs" | "sec" | "s" => Self::Seconds(value),
+            "minutes" | "minute" | "mins" | "min" => Self::Minutes(value),
+            "hours" | "hour" | "hr" => Self::Hours(value),
+            "days" | "day" | "d" => Self::Days(value),
             _ => {
                 return Err(DeError::invalid_value(
                     Unexpected::Str(unit),
@@ -381,12 +381,16 @@ mod tests {
         assert_eq!(duration, RawDuration::Millis(10));
         let duration: RawDuration = "50    seconds".parse().unwrap();
         assert_eq!(duration, RawDuration::Seconds(50));
+        let duration: RawDuration = "40s".parse().unwrap();
+        assert_eq!(duration, RawDuration::Seconds(40));
         let duration: RawDuration = "10 min".parse().unwrap();
         assert_eq!(duration, RawDuration::Minutes(10));
         let duration: RawDuration = "12 hours".parse().unwrap();
         assert_eq!(duration, RawDuration::Hours(12));
         let duration: RawDuration = "30d".parse().unwrap();
         assert_eq!(duration, RawDuration::Days(30));
+        let duration: RawDuration = "1 day".parse().unwrap();
+        assert_eq!(duration, RawDuration::Days(1));
     }
 
     #[test]

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -309,6 +309,7 @@ pub mod testing;
 #[cfg(test)]
 mod testonly;
 mod types;
+mod utils;
 pub mod value;
 
 /// Describes a configuration (i.e., a group of related parameters).

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -70,7 +70,7 @@
 //! }
 //!
 //! let mut schema = ConfigSchema::default();
-//! schema.insert::<TestConfig>("test")?;
+//! schema.insert(&TestConfig::DESCRIPTION, "test")?;
 //! // Assume we use two config sources: a YAML file and env vars,
 //! // the latter having higher priority.
 //! let yaml = r"

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -262,6 +262,8 @@ impl fmt::Display for TypeQualifiers {
 pub struct NestedConfigMetadata {
     /// Name of the config in config sources. Empty for flattened configs. Not necessarily the Rust field name!
     pub name: &'static str,
+    /// Aliases for the config. Cannot be present for flattened configs.
+    pub aliases: &'static [&'static str],
     /// Name of the config field in Rust code.
     pub rust_field_name: &'static str,
     /// Config metadata.

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -145,11 +145,6 @@ impl BasicTypes {
         Self(self.0 | rhs.0)
     }
 
-    pub(crate) fn and(self, rhs: Self) -> Option<Self> {
-        let raw = self.0 & rhs.0;
-        (raw > 0).then_some(Self(raw))
-    }
-
     /// Checks whether the `needle` is fully contained in this set.
     pub const fn contains(self, needle: Self) -> bool {
         self.0 & needle.0 == needle.0

--- a/crates/smart-config/src/metadata/validation.rs
+++ b/crates/smart-config/src/metadata/validation.rs
@@ -98,7 +98,7 @@ const fn validate_name(name: &str) -> Result<(), ValidationError> {
 pub const fn assert_param_name(name: &str) {
     if let Err(err) = validate_name(name) {
         compile_panic!(
-            "Param name `", name => clip(32, "…"), "` is invalid: ",
+            "Param / config name `", name => clip(32, "…"), "` is invalid: ",
             &err.fmt() => fmt::<&ErrorArgs>()
         );
     }

--- a/crates/smart-config/src/metadata/validation.rs
+++ b/crates/smart-config/src/metadata/validation.rs
@@ -126,6 +126,40 @@ const fn assert_param_against_config(
     config_parent: &'static str,
     config: &NestedConfigMetadata,
 ) {
+    let mut param_i = 0;
+    while param_i <= param.aliases.len() {
+        let param_name = if param_i == 0 {
+            param.name
+        } else {
+            param.aliases[param_i - 1]
+        };
+
+        let mut config_i = 0;
+        while config_i <= config.aliases.len() {
+            let config_name = if config_i == 0 {
+                config.name
+            } else {
+                config.aliases[config_i - 1]
+            };
+
+            if const_eq(param_name.as_bytes(), config_name.as_bytes()) {
+                compile_panic!(
+                    "Name / alias `", param_name => clip(32, "…"), "` of param `",
+                    param_parent => clip(32, "…"), ".",
+                    param.rust_field_name  => clip(32, "…"),
+                    "` coincides with a name / alias of a nested config `",
+                    config_parent => clip(32, "…"), ".",
+                    config.rust_field_name  => clip(32, "…"),
+                    "`. This is an unconditional error; \
+                    config deserialization relies on the fact that configs never coincide with params"
+                );
+            }
+
+            config_i += 1;
+        }
+        param_i += 1;
+    }
+
     if const_eq(param.name.as_bytes(), config.name.as_bytes()) {
         compile_panic!(
             "Name `", param.name => clip(32, "…"), "` of param `",

--- a/crates/smart-config/src/schema/tests.rs
+++ b/crates/smart-config/src/schema/tests.rs
@@ -72,7 +72,7 @@ fn getting_config_metadata() {
 fn using_alias() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<TestConfig>("test")
+        .insert(&TestConfig::DESCRIPTION, "test")
         .unwrap()
         .push_alias("")
         .unwrap();
@@ -104,7 +104,7 @@ fn using_alias() {
 fn using_multiple_aliases() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<TestConfig>("test")
+        .insert(&TestConfig::DESCRIPTION, "test")
         .unwrap()
         .push_alias("")
         .unwrap()
@@ -139,7 +139,7 @@ fn using_multiple_aliases() {
 #[test]
 fn using_nesting() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<NestingConfig>("").unwrap();
+    schema.insert(&NestingConfig::DESCRIPTION, "").unwrap();
 
     let config_prefixes: Vec<_> = schema.locate(&NestingConfig::DESCRIPTION).collect();
     assert_eq!(config_prefixes, [""]);
@@ -219,7 +219,7 @@ struct BogusNestedConfigWithAlias {
 #[test]
 fn mountpoint_errors() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<NestingConfig>("test").unwrap();
+    schema.insert(&NestingConfig::DESCRIPTION, "test").unwrap();
     assert_matches!(
         schema.mounting_points["test.hierarchical"],
         MountingPoint::Config
@@ -254,14 +254,14 @@ fn mountpoint_errors() {
     );
 
     let err = schema
-        .insert::<BogusParamConfig>("test")
+        .insert(&BogusParamConfig::DESCRIPTION, "test")
         .unwrap_err()
         .to_string();
     assert!(err.contains("[Rust field: `hierarchical`]"), "{err}");
     assert!(err.contains("config(s) are already mounted"), "{err}");
 
     let err = schema
-        .insert::<BogusNestedConfig>("test")
+        .insert(&BogusNestedConfig::DESCRIPTION, "test")
         .unwrap_err()
         .to_string();
     assert!(err.contains("Cannot mount config"), "{err}");
@@ -269,7 +269,7 @@ fn mountpoint_errors() {
     assert!(err.contains("parameter(s) are already mounted"), "{err}");
 
     let err = schema
-        .insert::<BogusNestedConfig>("test.bool_value")
+        .insert(&BogusNestedConfig::DESCRIPTION, "test.bool_value")
         .unwrap_err()
         .to_string();
     assert!(err.contains("Cannot mount config"), "{err}");
@@ -277,7 +277,7 @@ fn mountpoint_errors() {
     assert!(err.contains("parameter(s) are already mounted"), "{err}");
 
     let err = schema
-        .insert::<BogusParamTypeConfig>("test")
+        .insert(&BogusParamTypeConfig::DESCRIPTION, "test")
         .unwrap_err()
         .to_string();
     assert!(err.contains("Cannot insert param"), "{err}");
@@ -288,10 +288,10 @@ fn mountpoint_errors() {
 #[test]
 fn aliasing_mountpoint_errors() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<NestingConfig>("test").unwrap();
+    schema.insert(&NestingConfig::DESCRIPTION, "test").unwrap();
 
     let err = schema
-        .insert::<BogusParamConfig>("bogus")
+        .insert(&BogusParamConfig::DESCRIPTION, "bogus")
         .unwrap()
         .push_alias("test")
         .unwrap_err()
@@ -312,7 +312,7 @@ fn aliasing_mountpoint_errors() {
     );
 
     let err = schema
-        .insert::<BogusParamTypeConfig>("bogus")
+        .insert(&BogusParamTypeConfig::DESCRIPTION, "bogus")
         .unwrap()
         .push_alias("test")
         .unwrap_err()
@@ -325,10 +325,10 @@ fn aliasing_mountpoint_errors() {
 #[test]
 fn aliasing_mountpoint_errors_via_nested_configs() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<NestingConfig>("test").unwrap();
+    schema.insert(&NestingConfig::DESCRIPTION, "test").unwrap();
 
     let err = schema
-        .insert::<BogusNestedConfigWithAlias>("test")
+        .insert(&BogusNestedConfigWithAlias::DESCRIPTION, "test")
         .unwrap_err()
         .to_string();
     assert!(err.contains("Cannot mount config"), "{err}");
@@ -337,10 +337,12 @@ fn aliasing_mountpoint_errors_via_nested_configs() {
 
     // Mount a config at the location of a param of the nested config.
     let mut schema = ConfigSchema::default();
-    schema.insert::<TestConfig>("str.optional").unwrap();
+    schema
+        .insert(&TestConfig::DESCRIPTION, "str.optional")
+        .unwrap();
 
     let err = schema
-        .insert::<BogusNestedConfigWithAlias>("")
+        .insert(&BogusNestedConfigWithAlias::DESCRIPTION, "")
         .unwrap_err()
         .to_string();
     assert!(err.contains("Cannot insert param"), "{err}");
@@ -352,7 +354,7 @@ fn aliasing_mountpoint_errors_via_nested_configs() {
 fn aliasing_info_for_nested_configs() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<AliasedConfig>("test")
+        .insert(&AliasedConfig::DESCRIPTION, "test")
         .unwrap()
         .push_alias("alias")
         .unwrap();

--- a/crates/smart-config/src/schema/tests.rs
+++ b/crates/smart-config/src/schema/tests.rs
@@ -374,4 +374,18 @@ fn aliasing_info_for_nested_configs() {
         .aliases()
         .collect();
     assert_eq!(aliases, ["test.nest", "alias.nested", "alias.nest"]);
+
+    let param_paths = [
+        "test_nested_str",
+        "test_nested_string",
+        "alias_nested_str",
+        "alias_nest_string",
+    ];
+    for path in param_paths {
+        println!("Testing path: {path}");
+        let mut data: Vec<_> = schema.params_with_kv_path(path).collect();
+        assert_eq!(data.len(), 1);
+        let (_, expecting) = data.pop().unwrap();
+        assert_eq!(expecting, BasicTypes::STRING);
+    }
 }

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -268,6 +268,7 @@ impl WithOrigin {
         self.collect_garbage(schema, prefixes_for_canonical_configs, Pointer(""))
     }
 
+    // TODO: is it intentional that nested configs are not aliased?
     fn copy_aliased_values(&mut self, schema: &ConfigSchema) {
         for (prefix, config_data) in schema.iter_ll() {
             let canonical_map = match self.get(prefix).map(|val| &val.inner) {
@@ -279,8 +280,8 @@ impl WithOrigin {
             let alias_maps: Vec<_> = config_data
                 .aliases
                 .iter()
-                .filter_map(|&alias| {
-                    let val = self.get(alias)?;
+                .filter_map(|alias| {
+                    let val = self.get(Pointer(alias))?;
                     Some((val.inner.as_object()?, &val.origin))
                 })
                 .collect();

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashSet, iter, marker::PhantomData, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashSet},
+    iter,
+    marker::PhantomData,
+    sync::Arc,
+};
 
 pub use self::{env::Environment, json::Json, yaml::Yaml};
 use crate::{
@@ -265,6 +270,7 @@ impl WithOrigin {
         self.copy_aliased_values(schema);
         self.mark_secrets(schema);
         self.nest_object_params_and_sub_configs(schema);
+        self.nest_array_params(schema);
         self.collect_garbage(schema, prefixes_for_canonical_configs, Pointer(""))
     }
 
@@ -437,7 +443,7 @@ impl WithOrigin {
         }
     }
 
-    /// Nests values inside matching object params.
+    /// Nests values inside matching object params or nested configs.
     ///
     /// For example, we have an object param at `test.param` and a source with a value at `test.param_ms`.
     /// This transform will copy this value to `test.param.ms` (i.e., inside the param object), provided that
@@ -510,6 +516,60 @@ impl WithOrigin {
         }
     }
 
+    /// Nests values inside matching array params.
+    ///
+    /// For example, we have an array param at `test.param` and a source with values at `test.param_0`, `test.param_1`, `test.param_2`
+    /// (and no `test.param`). This transform will copy these values as a 3-element array at `test.param`.
+    fn nest_array_params(&mut self, schema: &ConfigSchema) {
+        for (prefix, config_data) in schema.iter_ll() {
+            let Some(config_object) = self.get_mut(prefix) else {
+                continue;
+            };
+            let config_origin = &config_object.origin;
+            let Value::Object(config_object) = &mut config_object.inner else {
+                continue;
+            };
+
+            for param in config_data.metadata.params {
+                if !param.expecting.contains(BasicTypes::ARRAY)
+                    || param.expecting.contains(BasicTypes::OBJECT)
+                {
+                    // If a param expects an object, a transform is ambiguous; `_${i}` suffix could be either an array index
+                    // or an object key.
+                    continue;
+                }
+                if config_object.contains_key(param.name) {
+                    // Unlike objects, we never extend existing arrays.
+                    continue;
+                }
+
+                let matching_fields: BTreeMap<_, _> = config_object
+                    .iter()
+                    .filter_map(|(name, field)| {
+                        let stripped_name = name.strip_prefix(param.name)?.strip_prefix('_')?;
+                        let idx: usize = stripped_name.parse().ok()?;
+                        Some((idx, field.clone()))
+                    })
+                    .collect();
+                let Some(&last_idx) = matching_fields.keys().next_back() else {
+                    continue; // No matching fields
+                };
+
+                if last_idx != matching_fields.len() - 1 {
+                    continue; // Fields are not sequential; TODO: log
+                }
+
+                let origin = Arc::new(ValueOrigin::Synthetic {
+                    source: config_origin.clone(),
+                    transform: format!("nesting for array param '{}'", param.name),
+                });
+                let array_items = matching_fields.into_values().collect();
+                let val = Self::new(Value::Array(array_items), origin);
+                config_object.insert(param.name.to_owned(), val);
+            }
+        }
+    }
+
     /// Nests a flat key–value map into a structured object using the provided `schema`.
     ///
     /// Has complexity `O(kvs.len() * log(n_params))`, which seems about the best possible option if `kvs` is not presorted.
@@ -535,21 +595,7 @@ impl WithOrigin {
                 for (param_path, expecting) in schema.params_with_kv_path(key_prefix) {
                     let should_copy = key_prefix == key || expecting.contains(BasicTypes::OBJECT);
                     if should_copy {
-                        // `unwrap()` is safe: params have non-empty paths
-                        let (parent, _) = param_path.split_last().unwrap();
-                        let field_name_start = if parent.0.is_empty() {
-                            parent.0.len()
-                        } else {
-                            parent.0.len() + 1 // skip `_` after the parent
-                        };
-                        let field_name = key[field_name_start..].to_owned();
-
-                        let origin = Arc::new(ValueOrigin::Synthetic {
-                            source: source_origin.clone(),
-                            transform: format!("nesting kv entries for '{param_path}'"),
-                        });
-                        dest.ensure_object(parent, |_| origin.clone())
-                            .insert(field_name, value.clone());
+                        dest.copy_kv_entry(source_origin, param_path, &key, value.clone());
                     }
                 }
 
@@ -558,8 +604,46 @@ impl WithOrigin {
                     None => break,
                 };
             }
+
+            // Allow for array params.
+            let Some((key_prefix, maybe_idx)) = key.rsplit_once('_') else {
+                continue;
+            };
+            if !maybe_idx.bytes().all(|ch| ch.is_ascii_digit()) {
+                continue;
+            }
+            for (param_path, expecting) in schema.params_with_kv_path(key_prefix) {
+                if expecting.contains(BasicTypes::ARRAY) && !expecting.contains(BasicTypes::OBJECT)
+                {
+                    dest.copy_kv_entry(source_origin, param_path, &key, value.clone());
+                }
+            }
         }
         dest
+    }
+
+    fn copy_kv_entry(
+        &mut self,
+        source_origin: &Arc<ValueOrigin>,
+        param_path: Pointer<'_>,
+        key: &str,
+        value: WithOrigin,
+    ) {
+        // `unwrap()` is safe: params have non-empty paths
+        let (parent, _) = param_path.split_last().unwrap();
+        let field_name_start = if parent.0.is_empty() {
+            parent.0.len()
+        } else {
+            parent.0.len() + 1 // skip `_` after the parent
+        };
+        let field_name = key[field_name_start..].to_owned();
+
+        let origin = Arc::new(ValueOrigin::Synthetic {
+            source: source_origin.clone(),
+            transform: format!("nesting kv entries for '{param_path}'"),
+        });
+        self.ensure_object(parent, |_| origin.clone())
+            .insert(field_name, value);
     }
 
     /// Deep merge stopped at params (i.e., params are always merged atomically).

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -274,7 +274,6 @@ impl WithOrigin {
         self.collect_garbage(schema, prefixes_for_canonical_configs, Pointer(""))
     }
 
-    // TODO: is it intentional that nested configs are not aliased?
     fn copy_aliased_values(&mut self, schema: &ConfigSchema) {
         for (prefix, config_data) in schema.iter_ll() {
             let canonical_map = match self.get(prefix).map(|val| &val.inner) {
@@ -284,8 +283,7 @@ impl WithOrigin {
             };
 
             let alias_maps: Vec<_> = config_data
-                .aliases
-                .iter()
+                .aliases()
                 .filter_map(|alias| {
                     let val = self.get(Pointer(alias))?;
                     Some((val.inner.as_object()?, &val.origin))

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -53,7 +53,7 @@ fn parsing_enum_config_with_schema() {
     assert!(inner.contains("unknown variant"), "{inner}");
     assert_eq!(err.path(), "renamed");
 
-    repo.deserializer_options().coerce_shouting_variant_names = true;
+    repo.deserializer_options().coerce_variant_names = true;
     let config: EnumConfig = repo.single().unwrap().parse().unwrap();
     assert_eq!(
         config,

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -367,6 +367,38 @@ fn merging_config_parts() {
 }
 
 #[test]
+fn using_nested_config_aliases() {
+    let json = config!(
+        "value": 10,
+        "nest.renamed": "first",
+        "nest.other_int": 50,
+    );
+    let config: ConfigWithNesting = testing::test(json).unwrap();
+    assert_eq!(config.nested.simple_enum, SimpleEnum::First);
+    assert_eq!(config.nested.other_int, 50);
+
+    // Mixing canonical path and aliases
+    let json = config!(
+        "value": 10,
+        "nested.renamed": "first",
+        "nest.other_int": 50,
+    );
+    let config: ConfigWithNesting = testing::test(json).unwrap();
+    assert_eq!(config.nested.simple_enum, SimpleEnum::First);
+    assert_eq!(config.nested.other_int, 50);
+
+    let json = config!(
+        "value": 10,
+        "nest.renamed": "first",
+        "nested.other_int": 777,
+        "nest.other_int": 50, // shouldn't be used since there's a canonical param
+    );
+    let config: ConfigWithNesting = testing::test(json).unwrap();
+    assert_eq!(config.nested.simple_enum, SimpleEnum::First);
+    assert_eq!(config.nested.other_int, 777);
+}
+
+#[test]
 fn merging_config_parts_with_env() {
     let env = Environment::from_iter("", [("deprecated_value", "4"), ("nested_renamed", "first")]);
 

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -15,7 +15,7 @@ use crate::{
         ConfigWithComplexTypes, ConfigWithNesting, DefaultingConfig, EnumConfig, KvTestConfig,
         NestedConfig, SecretConfig, SimpleEnum, ValueCoercingConfig,
     },
-    ByteSize,
+    ByteSize, DescribeConfig,
 };
 
 #[test]
@@ -309,7 +309,7 @@ fn merging_config_parts() {
         .push_alias("deprecated")
         .unwrap();
     schema
-        .single_mut::<NestedConfig>()
+        .single_mut(&NestedConfig::DESCRIPTION)
         .unwrap()
         .push_alias("deprecated")
         .unwrap();
@@ -377,7 +377,7 @@ fn merging_config_parts_with_env() {
         .push_alias("deprecated")
         .unwrap();
     schema
-        .single_mut::<NestedConfig>()
+        .single_mut(&NestedConfig::DESCRIPTION)
         .unwrap()
         .push_alias("deprecated")
         .unwrap();

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -21,7 +21,7 @@ use crate::{
 #[test]
 fn parsing_enum_config_with_schema() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<EnumConfig>("").unwrap();
+    schema.insert(&EnumConfig::DESCRIPTION, "").unwrap();
 
     let json = config!(
         "type": "Nested",
@@ -122,7 +122,9 @@ fn parsing_enum_config_with_schema() {
 #[test]
 fn parsing_defaulting_config_from_missing_value_with_schema() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<DefaultingConfig>("test").unwrap();
+    schema
+        .insert(&DefaultingConfig::DESCRIPTION, "test")
+        .unwrap();
     let json = config!("unrelated": 123);
     let repo = ConfigRepository::new(&schema).with(json);
     let config: DefaultingConfig = repo.single().unwrap().parse().unwrap();
@@ -138,7 +140,7 @@ fn parsing_compound_config_with_schema() {
     );
 
     let mut schema = ConfigSchema::default();
-    schema.insert::<CompoundConfig>("").unwrap();
+    schema.insert(&CompoundConfig::DESCRIPTION, "").unwrap();
     let repo = ConfigRepository::new(&schema).with(json);
     let config: CompoundConfig = repo.single().unwrap().parse().unwrap();
     assert_eq!(
@@ -163,7 +165,7 @@ fn parsing_compound_config_with_schema() {
 
 fn test_parsing_compound_config_with_schema_error(json: Json, expected_err_path: &str) {
     let mut schema = ConfigSchema::default();
-    schema.insert::<CompoundConfig>("").unwrap();
+    schema.insert(&CompoundConfig::DESCRIPTION, "").unwrap();
     let repo = ConfigRepository::new(&schema).with(json);
     let err = repo
         .single::<CompoundConfig>()
@@ -229,7 +231,7 @@ fn nesting_json() {
     );
 
     let mut schema = ConfigSchema::default();
-    schema.insert::<ConfigWithNesting>("").unwrap();
+    schema.insert(&ConfigWithNesting::DESCRIPTION, "").unwrap();
     let map = ConfigRepository::new(&schema).with(env).merged;
 
     assert_matches!(
@@ -259,7 +261,7 @@ fn nesting_inside_child_config() {
         "nested_other_int": 321,
     );
     let mut schema = ConfigSchema::default();
-    schema.insert::<ConfigWithNesting>("").unwrap();
+    schema.insert(&ConfigWithNesting::DESCRIPTION, "").unwrap();
     let map = ConfigRepository::new(&schema).with(json).merged;
 
     assert_matches!(
@@ -282,7 +284,7 @@ fn nesting_inside_child_config() {
         "nested.other_int": 777, // has priority
     );
     let mut schema = ConfigSchema::default();
-    schema.insert::<ConfigWithNesting>("").unwrap();
+    schema.insert(&ConfigWithNesting::DESCRIPTION, "").unwrap();
     let map = ConfigRepository::new(&schema).with(json).merged;
 
     assert_matches!(
@@ -304,7 +306,7 @@ fn merging_config_parts() {
 
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<ConfigWithNesting>("")
+        .insert(&ConfigWithNesting::DESCRIPTION, "")
         .unwrap()
         .push_alias("deprecated")
         .unwrap();
@@ -404,7 +406,7 @@ fn merging_config_parts_with_env() {
 
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<ConfigWithNesting>("")
+        .insert(&ConfigWithNesting::DESCRIPTION, "")
         .unwrap()
         .push_alias("deprecated")
         .unwrap();
@@ -467,7 +469,7 @@ fn merging_configs() {
     let overrides = Json::new("overrides.json", json);
 
     let mut schema = ConfigSchema::default();
-    schema.insert::<ConfigWithNesting>("").unwrap();
+    schema.insert(&ConfigWithNesting::DESCRIPTION, "").unwrap();
     let repo = ConfigRepository::new(&schema).with(base).with(overrides);
     let Value::Object(merged) = &repo.merged().inner else {
         panic!("unexpected merged value");
@@ -514,7 +516,7 @@ fn merging_configs() {
 fn using_aliases_with_object_config() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<ConfigWithNesting>("test")
+        .insert(&ConfigWithNesting::DESCRIPTION, "test")
         .unwrap()
         .push_alias("deprecated")
         .unwrap();
@@ -536,7 +538,7 @@ fn using_aliases_with_object_config() {
 fn using_env_config_overrides() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<ConfigWithNesting>("test")
+        .insert(&ConfigWithNesting::DESCRIPTION, "test")
         .unwrap()
         .push_alias("deprecated")
         .unwrap();
@@ -663,7 +665,9 @@ fn merging_params_is_atomic() {
         }),
     );
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "")
+        .unwrap();
     let repo = ConfigRepository::new(&schema).with(base).with(overrides);
     let param_value = &repo.merged().get(Pointer("param")).unwrap().inner;
     assert_matches!(
@@ -695,7 +699,9 @@ fn merging_params_is_still_atomic_with_prefixes() {
         "test.config.unused": true,
     );
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test.config").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test.config")
+        .unwrap();
     let repo = ConfigRepository::new(&schema).with(base).with(overrides);
     let param_value = &repo
         .merged()
@@ -716,7 +722,7 @@ fn merging_params_is_still_atomic_with_prefixes() {
 #[test]
 fn nesting_key_value_map_to_multiple_locations() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<KvTestConfig>("").unwrap();
+    schema.insert(&KvTestConfig::DESCRIPTION, "").unwrap();
 
     let mut repo = ConfigRepository::new(&schema);
     let config: KvTestConfig = repo.single().unwrap().parse().unwrap();
@@ -733,7 +739,9 @@ fn nesting_key_value_map_to_multiple_locations() {
 #[test]
 fn nesting_for_object_param() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test")
+        .unwrap();
 
     let env = Environment::from_iter("", [("TEST_PARAM_INT", "123"), ("TEST_PARAM_STRING", "??")]);
     let repo = ConfigRepository::new(&schema).with(env);
@@ -756,7 +764,9 @@ fn nesting_for_object_param() {
 #[test]
 fn nesting_for_object_param_with_structured_source() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test")
+        .unwrap();
 
     let json = config!(
         "test.param_int": 123,
@@ -778,7 +788,9 @@ fn nesting_for_object_param_with_structured_source() {
 #[test]
 fn nesting_for_array_param() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test")
+        .unwrap();
 
     let env = Environment::from_iter(
         "",
@@ -819,7 +831,9 @@ fn nesting_for_array_param() {
 #[test]
 fn nesting_not_applied_if_original_param_is_defined() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test")
+        .unwrap();
 
     let env = Environment::from_iter(
         "",
@@ -851,7 +865,9 @@ fn nesting_not_applied_if_original_param_is_defined() {
 #[test]
 fn nesting_not_applied_for_non_sequential_array_indices() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test")
+        .unwrap();
 
     let env = Environment::from_iter("", [("TEST_SET_1", "123"), ("TEST_SET_2", "321")]);
     let repo = ConfigRepository::new(&schema).with(env);
@@ -867,7 +883,9 @@ fn nesting_not_applied_for_non_sequential_array_indices() {
 #[test]
 fn nesting_does_not_override_existing_values() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ValueCoercingConfig>("test").unwrap();
+    schema
+        .insert(&ValueCoercingConfig::DESCRIPTION, "test")
+        .unwrap();
 
     let json = config!(
         "test.param_int": 123,
@@ -970,7 +988,9 @@ fn nesting_with_duration_param_errors() {
 #[test]
 fn merging_duration_params_is_atomic() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<ConfigWithComplexTypes>("test").unwrap();
+    schema
+        .insert(&ConfigWithComplexTypes::DESCRIPTION, "test")
+        .unwrap();
 
     // Base case: the duration is defined only in overrides
     let base = config!("test.array": [4, 5]);
@@ -1112,7 +1132,7 @@ fn nesting_with_composed_deserializers_errors() {
 #[test]
 fn reading_secrets() {
     let mut schema = ConfigSchema::default();
-    schema.insert::<SecretConfig>("").unwrap();
+    schema.insert(&SecretConfig::DESCRIPTION, "").unwrap();
     let env = Environment::from_iter("APP_", [("APP_KEY", "super_secret")]);
     let mut repo = ConfigRepository::new(&schema).with(env);
 
@@ -1169,7 +1189,7 @@ fn reading_secrets() {
 fn aliasing_for_flattened_config() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<AliasedConfig>("test")
+        .insert(&AliasedConfig::DESCRIPTION, "test")
         .unwrap()
         .push_alias("alias")
         .unwrap();
@@ -1197,7 +1217,7 @@ fn aliasing_for_flattened_config() {
 fn aliasing_for_nested_config() {
     let mut schema = ConfigSchema::default();
     schema
-        .insert::<AliasedConfig>("test")
+        .insert(&AliasedConfig::DESCRIPTION, "test")
         .unwrap()
         .push_alias("alias")
         .unwrap();

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -157,7 +157,7 @@ pub struct Tester<C> {
 impl<C: DeserializeConfig> Default for Tester<C> {
     fn default() -> Self {
         let mut schema = ConfigSchema::default();
-        schema.insert::<C>("").unwrap();
+        schema.insert(&C::DESCRIPTION, "").unwrap();
         Self {
             de_options: DeserializerOptions::default(),
             schema,

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -1,8 +1,9 @@
 //! Testing tools for configurations.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, marker::PhantomData};
 
 use crate::{
+    de::DeserializerOptions,
     metadata::{ConfigMetadata, RustType},
     schema::ConfigSchema,
     value::{Pointer, WithOrigin},
@@ -58,12 +59,8 @@ use crate::{
 ///     .to_string()
 ///     .contains("provided string was not `true` or `false`"));
 /// ```
-#[allow(clippy::missing_panics_doc)] // can only panic if the config is recursively defined, which is impossible
 pub fn test<C: DeserializeConfig>(sample: impl ConfigSource) -> Result<C, ParseErrors> {
-    let mut schema = ConfigSchema::default();
-    schema.insert::<C>("").unwrap();
-    let repo = ConfigRepository::new(&schema).with(sample);
-    repo.single::<C>().unwrap().parse()
+    Tester::default().test(sample)
 }
 
 /// Tests config deserialization ensuring that *all* declared config params are covered.
@@ -119,27 +116,7 @@ pub fn test<C: DeserializeConfig>(sample: impl ConfigSource) -> Result<C, ParseE
 /// # anyhow::Ok(())
 /// ```
 pub fn test_complete<C: DeserializeConfig>(sample: impl ConfigSource) -> Result<C, ParseErrors> {
-    let mut schema = ConfigSchema::default();
-    schema.insert::<C>("").unwrap();
-    let repo = ConfigRepository::new(&schema).with(sample);
-
-    let metadata = &C::DESCRIPTION;
-    let mut missing_params = HashMap::new();
-    let mut missing_configs = HashMap::new();
-    check_params(
-        Pointer(""),
-        repo.merged(),
-        metadata,
-        &mut missing_params,
-        &mut missing_configs,
-    );
-
-    assert!(
-        missing_params.is_empty() && missing_configs.is_empty(),
-        "The provided sample is incomplete; missing params: {missing_params:?}, missing configs: {missing_configs:?}"
-    );
-
-    repo.single::<C>().unwrap().parse()
+    Tester::default().test_complete(sample)
 }
 
 fn check_params(
@@ -166,6 +143,88 @@ fn check_params(
             missing_params,
             missing_configs,
         );
+    }
+}
+
+/// Test case builder that allows configuring deserialization options etc.
+#[derive(Debug)]
+pub struct Tester<C> {
+    de_options: DeserializerOptions,
+    schema: ConfigSchema,
+    _config: PhantomData<C>,
+}
+
+impl<C: DeserializeConfig> Default for Tester<C> {
+    fn default() -> Self {
+        let mut schema = ConfigSchema::default();
+        schema.insert::<C>("").unwrap();
+        Self {
+            de_options: DeserializerOptions::default(),
+            schema,
+            _config: PhantomData,
+        }
+    }
+}
+
+impl<C: DeserializeConfig> Tester<C> {
+    /// Enables coercion of enum variant names.
+    pub fn coerce_variant_names(&mut self) -> &mut Self {
+        self.de_options.coerce_variant_names = true;
+        self
+    }
+
+    /// Tests config deserialization from the provided `sample`. Takes into account param aliases,
+    /// performs `sample` preprocessing etc.
+    ///
+    /// # Errors
+    ///
+    /// Propagates parsing errors, which allows testing negative cases.
+    ///
+    /// # Examples
+    ///
+    /// See [`test()`] for the examples of usage.
+    #[allow(clippy::missing_panics_doc)] // can only panic if the config is recursively defined, which is impossible
+    pub fn test(&self, sample: impl ConfigSource) -> Result<C, ParseErrors> {
+        let mut repo = ConfigRepository::new(&self.schema).with(sample);
+        *repo.deserializer_options() = self.de_options.clone();
+        repo.single::<C>().unwrap().parse()
+    }
+
+    /// Tests config deserialization ensuring that *all* declared config params are covered.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `sample` doesn't recursively cover all params in the config. The config message
+    /// will contain paths to the missing params.
+    ///
+    /// # Errors
+    ///
+    /// Propagates parsing errors, which allows testing negative cases.
+    ///
+    /// # Examples
+    ///
+    /// See [`test_complete()`] for the examples of usage.
+    pub fn test_complete(&self, sample: impl ConfigSource) -> Result<C, ParseErrors> {
+        let mut repo = ConfigRepository::new(&self.schema).with(sample);
+        *repo.deserializer_options() = self.de_options.clone();
+
+        let metadata = &C::DESCRIPTION;
+        let mut missing_params = HashMap::new();
+        let mut missing_configs = HashMap::new();
+        check_params(
+            Pointer(""),
+            repo.merged(),
+            metadata,
+            &mut missing_params,
+            &mut missing_configs,
+        );
+
+        assert!(
+            missing_params.is_empty() && missing_configs.is_empty(),
+            "The provided sample is incomplete; missing params: {missing_params:?}, missing configs: {missing_configs:?}"
+        );
+
+        repo.single::<C>().unwrap().parse()
     }
 }
 

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -247,6 +247,23 @@ pub(crate) struct SecretConfig {
     pub seq: Vec<u64>,
 }
 
+#[derive(DescribeConfig, DeserializeConfig)]
+#[config(crate = crate)]
+pub(crate) struct NestedAliasedConfig {
+    #[config(default, alias = "string")]
+    pub str: String,
+}
+
+#[derive(DescribeConfig, DeserializeConfig)]
+#[config(crate = crate)]
+pub(crate) struct AliasedConfig {
+    pub int: u32,
+    #[config(nest, alias = "nest")]
+    pub nested: NestedAliasedConfig,
+    #[config(flatten)]
+    pub flat: NestedAliasedConfig,
+}
+
 pub(crate) fn wrap_into_value(env: Environment) -> WithOrigin {
     let ConfigContents::KeyValue(map) = env.into_contents() else {
         unreachable!();

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -59,6 +59,8 @@ pub(crate) struct ValueCoercingConfig {
     pub param: TestParam,
     #[config(default)]
     pub set: HashSet<u64>,
+    #[config(default)]
+    pub repeated: Vec<TestParam>,
 }
 
 #[derive(Debug, PartialEq, DescribeConfig, DeserializeConfig)]

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -88,7 +88,7 @@ pub(crate) struct ConfigWithNesting {
     pub value: u32,
     #[config(default, alias = "alias")]
     pub merged: String,
-    #[config(nest)]
+    #[config(nest, alias = "nest")]
     pub nested: NestedConfig,
 }
 

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -25,6 +25,7 @@ use crate::{
 #[derive(Debug, PartialEq, Eq, Hash, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum SimpleEnum {
+    #[serde(alias = "first_choice")]
     First,
     Second,
 }

--- a/crates/smart-config/src/utils.rs
+++ b/crates/smart-config/src/utils.rs
@@ -127,16 +127,16 @@ impl<'a> EnumVariant<'a> {
         let sep = match to_case {
             TargetCase::LowerCase | TargetCase::UpperCase | TargetCase::CamelCase => None,
             TargetCase::SnakeCase | TargetCase::ScreamingSnakeCase => Some('_'),
-            TargetCase::KebabCase | TargetCase::ScreamingKebabCase => Some('-')
+            TargetCase::KebabCase | TargetCase::ScreamingKebabCase => Some('-'),
         };
         for (i, &word) in self.words.iter().enumerate() {
             dest.push_str(&match to_case {
                 TargetCase::LowerCase | TargetCase::SnakeCase | TargetCase::KebabCase => {
                     word.to_ascii_lowercase()
                 }
-                TargetCase::UpperCase | TargetCase::ScreamingSnakeCase | TargetCase::ScreamingKebabCase => {
-                    word.to_ascii_uppercase()
-                }
+                TargetCase::UpperCase
+                | TargetCase::ScreamingSnakeCase
+                | TargetCase::ScreamingKebabCase => word.to_ascii_uppercase(),
                 TargetCase::CamelCase => {
                     word[..1].to_ascii_uppercase() + &word[1..].to_ascii_lowercase()
                 }
@@ -243,10 +243,22 @@ mod tests {
         assert_eq!(variant.transform(TargetCase::LowerCase), "snakecase10u12i");
         assert_eq!(variant.transform(TargetCase::UpperCase), "SNAKECASE10U12I");
         assert_eq!(variant.transform(TargetCase::CamelCase), "SnakeCase10U12i");
-        assert_eq!(variant.transform(TargetCase::SnakeCase), "snake_case10_u12i");
-        assert_eq!(variant.transform(TargetCase::ScreamingSnakeCase), "SNAKE_CASE10_U12I");
-        assert_eq!(variant.transform(TargetCase::KebabCase), "snake-case10-u12i");
-        assert_eq!(variant.transform(TargetCase::ScreamingKebabCase), "SNAKE-CASE10-U12I");
+        assert_eq!(
+            variant.transform(TargetCase::SnakeCase),
+            "snake_case10_u12i"
+        );
+        assert_eq!(
+            variant.transform(TargetCase::ScreamingSnakeCase),
+            "SNAKE_CASE10_U12I"
+        );
+        assert_eq!(
+            variant.transform(TargetCase::KebabCase),
+            "snake-case10-u12i"
+        );
+        assert_eq!(
+            variant.transform(TargetCase::ScreamingKebabCase),
+            "SNAKE-CASE10-U12I"
+        );
     }
 
     #[test]

--- a/crates/smart-config/src/utils.rs
+++ b/crates/smart-config/src/utils.rs
@@ -1,0 +1,265 @@
+#![allow(clippy::enum_variant_names)]
+
+#[derive(Debug, Clone, Copy)]
+enum VariantCase {
+    // lowercase / uppercase are not supported because they don't provide word boundaries
+    CamelCase,
+    SnakeCase,
+    ScreamingSnakeCase,
+    KebabCase,
+    ScreamingKebabCase,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TargetCase {
+    LowerCase,
+    UpperCase,
+    CamelCase,
+    SnakeCase,
+    ScreamingSnakeCase,
+    KebabCase,
+    ScreamingKebabCase,
+}
+
+impl TargetCase {
+    const ALL: [Self; 7] = [
+        Self::LowerCase,
+        Self::UpperCase,
+        Self::CamelCase,
+        Self::SnakeCase,
+        Self::ScreamingSnakeCase,
+        Self::KebabCase,
+        Self::ScreamingKebabCase,
+    ];
+}
+
+#[derive(Debug)]
+pub(crate) struct EnumVariant<'a> {
+    raw: &'a str,
+    words: Vec<&'a str>,
+    #[allow(dead_code)] // used for tests
+    case: VariantCase,
+}
+
+impl<'a> EnumVariant<'a> {
+    pub(crate) fn new(raw: &'a str) -> Option<Self> {
+        if raw.is_empty() || !raw.is_ascii() {
+            return None;
+        }
+
+        let mut sep = None::<u8>;
+        let mut words = vec![];
+        let mut word_start = 0;
+        let mut is_lowercase = true;
+        let mut is_uppercase = true;
+        for (pos, ch) in raw.bytes().enumerate() {
+            match ch {
+                b'-' | b'_' => {
+                    if let Some(prev_sep) = sep {
+                        if prev_sep != ch {
+                            return None; // Inconsistent separator
+                        }
+                    }
+                    if word_start == pos {
+                        // Two separators in a row
+                        return None;
+                    }
+
+                    sep = Some(ch);
+                    let word = &raw[word_start..pos];
+                    if !word.is_empty() {
+                        words.push(word);
+                    }
+                    word_start = pos + 1;
+                }
+                ch if ch.is_ascii_alphanumeric() => {
+                    // Part of a word.
+                    if ch.is_ascii_uppercase() {
+                        is_lowercase = false;
+                    } else if ch.is_ascii_lowercase() {
+                        is_uppercase = false;
+                    }
+                }
+                _ => return None, // Unknown separator
+            }
+
+            if !is_lowercase && !is_uppercase && sep.is_some() {
+                return None; // Mixed case + splitter
+            }
+        }
+        let last_word = &raw[word_start..];
+        if !last_word.is_empty() {
+            words.push(last_word);
+        }
+        if words.is_empty() {
+            return None; // Degenerate case like `_`
+        }
+
+        let case = match sep {
+            Some(b'_') | None if is_lowercase => VariantCase::SnakeCase,
+            Some(b'_') | None if is_uppercase => VariantCase::ScreamingSnakeCase,
+            Some(b'-') if is_lowercase => VariantCase::KebabCase,
+            Some(b'-') if is_uppercase => VariantCase::ScreamingKebabCase,
+            None => {
+                // Guaranteed to have mixed case at this point.
+                debug_assert_eq!(words.len(), 1);
+
+                words.clear();
+                let mut word_start = 0;
+                for (pos, ch) in raw.bytes().enumerate() {
+                    if ch.is_ascii_uppercase() && pos > 0 {
+                        words.push(&raw[word_start..pos]);
+                        word_start = pos;
+                    }
+                }
+                words.push(&raw[word_start..]);
+
+                VariantCase::CamelCase
+            }
+            _ => return None, // mixed case etc.
+        };
+
+        Some(Self { raw, words, case })
+    }
+
+    fn transform(&self, to_case: TargetCase) -> String {
+        let mut dest = String::new();
+        let sep = match to_case {
+            TargetCase::LowerCase | TargetCase::UpperCase | TargetCase::CamelCase => None,
+            TargetCase::SnakeCase | TargetCase::ScreamingSnakeCase => Some('_'),
+            TargetCase::KebabCase | TargetCase::ScreamingKebabCase => Some('-')
+        };
+        for (i, &word) in self.words.iter().enumerate() {
+            dest.push_str(&match to_case {
+                TargetCase::LowerCase | TargetCase::SnakeCase | TargetCase::KebabCase => {
+                    word.to_ascii_lowercase()
+                }
+                TargetCase::UpperCase | TargetCase::ScreamingSnakeCase | TargetCase::ScreamingKebabCase => {
+                    word.to_ascii_uppercase()
+                }
+                TargetCase::CamelCase => {
+                    word[..1].to_ascii_uppercase() + &word[1..].to_ascii_lowercase()
+                }
+            });
+            let is_last = i + 1 == self.words.len();
+            if let (Some(sep), false) = (sep, is_last) {
+                dest.push(sep);
+            }
+        }
+        dest
+    }
+
+    // This logic can be optimized, e.g. by detecting the case in `variants`.
+    pub(crate) fn try_match(&self, variants: &[&'static str]) -> Option<&'static str> {
+        // First, search a complete match to provide a shortcut for the common case.
+        let matching = variants.iter().copied().find(|&var| var == self.raw);
+        if let Some(matching) = matching {
+            return Some(matching);
+        }
+
+        for to_case in TargetCase::ALL {
+            let transformed = self.transform(to_case);
+            let matching = variants.iter().copied().find(|&var| var == transformed);
+            if let Some(matching) = matching {
+                return Some(matching);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+
+    #[test]
+    fn detecting_cases() {
+        let variant = EnumVariant::new("snake_case10_12").unwrap();
+        assert_matches!(variant.case, VariantCase::SnakeCase);
+        assert_eq!(variant.words, ["snake", "case10", "12"]);
+
+        let variant = EnumVariant::new("03_snake_case").unwrap();
+        assert_matches!(variant.case, VariantCase::SnakeCase);
+        assert_eq!(variant.words, ["03", "snake", "case"]);
+
+        let variant = EnumVariant::new("SNAKE_CASE10_12").unwrap();
+        assert_matches!(variant.case, VariantCase::ScreamingSnakeCase);
+        assert_eq!(variant.words, ["SNAKE", "CASE10", "12"]);
+
+        let variant = EnumVariant::new("kebab-case10-12").unwrap();
+        assert_matches!(variant.case, VariantCase::KebabCase);
+        assert_eq!(variant.words, ["kebab", "case10", "12"]);
+
+        let variant = EnumVariant::new("KEBAB-CASE10-12").unwrap();
+        assert_matches!(variant.case, VariantCase::ScreamingKebabCase);
+        assert_eq!(variant.words, ["KEBAB", "CASE10", "12"]);
+
+        let variant = EnumVariant::new("CamelCase10").unwrap();
+        assert_matches!(variant.case, VariantCase::CamelCase);
+        assert_eq!(variant.words, ["Camel", "Case10"]);
+
+        let variant = EnumVariant::new("CamelCaseC").unwrap();
+        assert_matches!(variant.case, VariantCase::CamelCase);
+        assert_eq!(variant.words, ["Camel", "Case", "C"]);
+    }
+
+    #[test]
+    fn detecting_case_in_single_word() {
+        let variant = EnumVariant::new("snake").unwrap();
+        assert_matches!(variant.case, VariantCase::SnakeCase);
+        assert_eq!(variant.words, ["snake"]);
+
+        let variant = EnumVariant::new("SNAKE").unwrap();
+        assert_matches!(variant.case, VariantCase::ScreamingSnakeCase);
+        assert_eq!(variant.words, ["SNAKE"]);
+
+        let variant = EnumVariant::new("Camel").unwrap();
+        assert_matches!(variant.case, VariantCase::CamelCase);
+        assert_eq!(variant.words, ["Camel"]);
+    }
+
+    #[test]
+    fn detecting_no_case() {
+        // Not ASCII
+        let variant = EnumVariant::new("змея");
+        assert!(variant.is_none(), "{variant:?}");
+
+        // Unknown separator
+        let variant = EnumVariant::new("snake!case10");
+        assert!(variant.is_none(), "{variant:?}");
+
+        // Mixed separator
+        let variant = EnumVariant::new("snake_case10-12");
+        assert!(variant.is_none(), "{variant:?}");
+
+        // Mixed case + separator
+        let variant = EnumVariant::new("snake_Case10_12");
+        assert!(variant.is_none(), "{variant:?}");
+    }
+
+    fn assert_case_transforms(variant: &EnumVariant) {
+        assert_eq!(variant.transform(TargetCase::LowerCase), "snakecase10u12i");
+        assert_eq!(variant.transform(TargetCase::UpperCase), "SNAKECASE10U12I");
+        assert_eq!(variant.transform(TargetCase::CamelCase), "SnakeCase10U12i");
+        assert_eq!(variant.transform(TargetCase::SnakeCase), "snake_case10_u12i");
+        assert_eq!(variant.transform(TargetCase::ScreamingSnakeCase), "SNAKE_CASE10_U12I");
+        assert_eq!(variant.transform(TargetCase::KebabCase), "snake-case10-u12i");
+        assert_eq!(variant.transform(TargetCase::ScreamingKebabCase), "SNAKE-CASE10-U12I");
+    }
+
+    #[test]
+    fn transforming_case() {
+        let variant = EnumVariant::new("snake_case10_u12i").unwrap();
+        assert_case_transforms(&variant);
+        let variant = EnumVariant::new("SNAKE_CASE10_U12I").unwrap();
+        assert_case_transforms(&variant);
+        let variant = EnumVariant::new("snake-case10-u12i").unwrap();
+        assert_case_transforms(&variant);
+        let variant = EnumVariant::new("SNAKE-CASE10-U12I").unwrap();
+        assert_case_transforms(&variant);
+        let variant = EnumVariant::new("SnakeCase10U12i").unwrap();
+        assert_case_transforms(&variant);
+    }
+}

--- a/crates/smart-config/tests/ui/derives/bogus_alias_name.stderr
+++ b/crates/smart-config/tests/ui/derives/bogus_alias_name.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/derives/bogus_alias_name.rs:5:22
   |
 5 |     #[config(alias = "what?")]
-  |                      ^^^^^^^ the evaluated program panicked at 'Param name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/derives/bogus_alias_name.rs:5:22
+  |                      ^^^^^^^ the evaluated program panicked at 'Param / config name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/derives/bogus_alias_name.rs:5:22

--- a/crates/smart-config/tests/ui/derives/bogus_alias_name_for_config.rs
+++ b/crates/smart-config/tests/ui/derives/bogus_alias_name_for_config.rs
@@ -1,0 +1,14 @@
+use smart_config::DescribeConfig;
+
+#[derive(DescribeConfig)]
+struct NestedConfig {
+    field: u64,
+}
+
+#[derive(DescribeConfig)]
+struct TestConfig {
+    #[config(nest, alias = "what?")]
+    nested: NestedConfig,
+}
+
+fn main() {}

--- a/crates/smart-config/tests/ui/derives/bogus_alias_name_for_config.stderr
+++ b/crates/smart-config/tests/ui/derives/bogus_alias_name_for_config.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation of constant value failed
+  --> tests/ui/derives/bogus_alias_name_for_config.rs:10:28
+   |
+10 |     #[config(nest, alias = "what?")]
+   |                            ^^^^^^^ the evaluated program panicked at 'Param / config name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/derives/bogus_alias_name_for_config.rs:10:28

--- a/crates/smart-config/tests/ui/derives/bogus_nested_name.rs
+++ b/crates/smart-config/tests/ui/derives/bogus_nested_name.rs
@@ -1,0 +1,14 @@
+use smart_config::DescribeConfig;
+
+#[derive(DescribeConfig)]
+struct NestedConfig {
+    field: u64,
+}
+
+#[derive(DescribeConfig)]
+struct TestConfig {
+    #[config(nest, rename = "what?")]
+    nested: NestedConfig,
+}
+
+fn main() {}

--- a/crates/smart-config/tests/ui/derives/bogus_nested_name.stderr
+++ b/crates/smart-config/tests/ui/derives/bogus_nested_name.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation of constant value failed
+  --> tests/ui/derives/bogus_nested_name.rs:10:29
+   |
+10 |     #[config(nest, rename = "what?")]
+   |                             ^^^^^^^ the evaluated program panicked at 'Param / config name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/derives/bogus_nested_name.rs:10:29

--- a/crates/smart-config/tests/ui/derives/bogus_param_name.stderr
+++ b/crates/smart-config/tests/ui/derives/bogus_param_name.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/derives/bogus_param_name.rs:5:23
   |
 5 |     #[config(rename = "what?")]
-  |                       ^^^^^^^ the evaluated program panicked at 'Param name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/derives/bogus_param_name.rs:5:23
+  |                       ^^^^^^^ the evaluated program panicked at 'Param / config name `what?` is invalid: name contains a disallowed char '?' at position 4; allowed chars are [_a-z0-9]', $DIR/tests/ui/derives/bogus_param_name.rs:5:23

--- a/crates/smart-config/tests/ui/derives/bogus_param_raw_name.stderr
+++ b/crates/smart-config/tests/ui/derives/bogus_param_raw_name.stderr
@@ -2,4 +2,4 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/derives/bogus_param_raw_name.rs:5:5
   |
 5 |     r#поле: u64,
-  |     ^^^^^^ the evaluated program panicked at 'Param name `поле` is invalid: name contains non-ASCII chars, first at position 0', $DIR/tests/ui/derives/bogus_param_raw_name.rs:5:5
+  |     ^^^^^^ the evaluated program panicked at 'Param / config name `поле` is invalid: name contains non-ASCII chars, first at position 0', $DIR/tests/ui/derives/bogus_param_raw_name.rs:5:5

--- a/crates/smart-config/tests/ui/derives/flattened_config_with_alias.stderr
+++ b/crates/smart-config/tests/ui/derives/flattened_config_with_alias.stderr
@@ -1,4 +1,4 @@
-error: aliases for nested / flattened configs are not supported yet
+error: aliases for flattened configs are not supported yet; did you mean to make a config nested?
   --> tests/ui/derives/flattened_config_with_alias.rs:10:30
    |
 10 |     #[config(alias = "flat", flatten)]

--- a/crates/smart-config/tests/ui/derives/param_coinciding_with_config.stderr
+++ b/crates/smart-config/tests/ui/derives/param_coinciding_with_config.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
  --> tests/ui/derives/param_coinciding_with_config.rs:8:10
   |
 8 | #[derive(DescribeConfig)]
-  |          ^^^^^^^^^^^^^^ the evaluated program panicked at 'Alias `nested` of param `TestConfig.field` coincides with a name of a nested config `TestConfig.nested`. This is an unconditional error; config deserialization relies on the fact that configs never coincide with params', $DIR/tests/ui/derives/param_coinciding_with_config.rs:8:10
+  |          ^^^^^^^^^^^^^^ the evaluated program panicked at 'Name / alias `nested` of param `TestConfig.field` coincides with a name / alias of a nested config `TestConfig.nested`. This is an unconditional error; config deserialization relies on the fact that configs never coincide with params', $DIR/tests/ui/derives/param_coinciding_with_config.rs:8:10
   |
   = note: this error originates in the derive macro `DescribeConfig` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/smart-config/tests/ui/derives/param_coinciding_with_config_alias.rs
+++ b/crates/smart-config/tests/ui/derives/param_coinciding_with_config_alias.rs
@@ -1,0 +1,15 @@
+use smart_config::DescribeConfig;
+
+#[derive(DescribeConfig)]
+struct NestedConfig {
+    str: String,
+}
+
+#[derive(DescribeConfig)]
+struct TestConfig {
+    field: u64,
+    #[config(nest, alias = "field")]
+    nested: NestedConfig,
+}
+
+fn main() {}

--- a/crates/smart-config/tests/ui/derives/param_coinciding_with_config_alias.stderr
+++ b/crates/smart-config/tests/ui/derives/param_coinciding_with_config_alias.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+ --> tests/ui/derives/param_coinciding_with_config_alias.rs:8:10
+  |
+8 | #[derive(DescribeConfig)]
+  |          ^^^^^^^^^^^^^^ the evaluated program panicked at 'Name / alias `field` of param `TestConfig.field` coincides with a name / alias of a nested config `TestConfig.nested`. This is an unconditional error; config deserialization relies on the fact that configs never coincide with params', $DIR/tests/ui/derives/param_coinciding_with_config_alias.rs:8:10
+  |
+  = note: this error originates in the derive macro `DescribeConfig` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/smart-config/tests/ui/derives/param_coinciding_with_flattened_config.stderr
+++ b/crates/smart-config/tests/ui/derives/param_coinciding_with_flattened_config.stderr
@@ -2,6 +2,6 @@ error[E0080]: evaluation of constant value failed
   --> tests/ui/derives/param_coinciding_with_flattened_config.rs:14:10
    |
 14 | #[derive(DescribeConfig)]
-   |          ^^^^^^^^^^^^^^ the evaluated program panicked at 'Name `nested` of param `TestConfig.nested` coincides with a name of a nested config `FlattenedConfig.nested`. This is an unconditional error; config deserialization relies on the fact that configs never coincide with params', $DIR/tests/ui/derives/param_coinciding_with_flattened_config.rs:14:10
+   |          ^^^^^^^^^^^^^^ the evaluated program panicked at 'Name / alias `nested` of param `TestConfig.nested` coincides with a name / alias of a nested config `FlattenedConfig.nested`. This is an unconditional error; config deserialization relies on the fact that configs never coincide with params', $DIR/tests/ui/derives/param_coinciding_with_flattened_config.rs:14:10
    |
    = note: this error originates in the derive macro `DescribeConfig` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/smart-config/tests/ui/derives/param_coinciding_with_flattened_config_alias.rs
+++ b/crates/smart-config/tests/ui/derives/param_coinciding_with_flattened_config_alias.rs
@@ -1,0 +1,21 @@
+use smart_config::DescribeConfig;
+
+#[derive(DescribeConfig)]
+struct NestedConfig {
+    str: String,
+}
+
+#[derive(DescribeConfig)]
+struct FlattenedConfig {
+    #[config(nest, alias = "value")]
+    nested: NestedConfig,
+}
+
+#[derive(DescribeConfig)]
+struct TestConfig {
+    value: u64,
+    #[config(flatten)]
+    flat: FlattenedConfig,
+}
+
+fn main() {}

--- a/crates/smart-config/tests/ui/derives/param_coinciding_with_flattened_config_alias.stderr
+++ b/crates/smart-config/tests/ui/derives/param_coinciding_with_flattened_config_alias.stderr
@@ -1,0 +1,7 @@
+error[E0080]: evaluation of constant value failed
+  --> tests/ui/derives/param_coinciding_with_flattened_config_alias.rs:14:10
+   |
+14 | #[derive(DescribeConfig)]
+   |          ^^^^^^^^^^^^^^ the evaluated program panicked at 'Name / alias `value` of param `TestConfig.value` coincides with a name / alias of a nested config `FlattenedConfig.nested`. This is an unconditional error; config deserialization relies on the fact that configs never coincide with params', $DIR/tests/ui/derives/param_coinciding_with_flattened_config_alias.rs:14:10
+   |
+   = note: this error originates in the derive macro `DescribeConfig` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
# What ❔

Adds more missing features for the Era codebase:

- Extended coercion of enum variant names.
- Aliases for nested configs + more complete processing of aliases (previously, aliases were only applied to params, not sub-configs; now they are applied to both recursively).
- More duration unit aliases (e.g., "s" for seconds).
- Bug fixes.

## Why ❔

Required for Era integration.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.