### PR TITLE
feat: Serializing config params

### DIFF
--- a/crates/smart-config-commands/Cargo.toml
+++ b/crates/smart-config-commands/Cargo.toml
@@ -13,6 +13,7 @@ description = "Command-line extensions for `smart-config` library"
 [dependencies]
 anstream.workspace = true
 anstyle.workspace = true
+serde_json.workspace = true
 smart-config.workspace = true
 
 [dev-dependencies]
@@ -22,7 +23,6 @@ clap = { workspace = true, features = ["derive"] }
 doc-comment.workspace = true
 primitive-types.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 serde_yaml.workspace = true
 version-sync.workspace = true
 

--- a/crates/smart-config-commands/examples/cli.rs
+++ b/crates/smart-config-commands/examples/cli.rs
@@ -8,7 +8,7 @@ use std::{
 
 use clap::Parser;
 use primitive_types::{H160 as Address, H256, U256};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Serialize};
 use smart_config::{
     de, fallback,
     metadata::{SizeUnit, TimeUnit},
@@ -70,7 +70,7 @@ pub struct NestedConfig {
     pub method_limits: HashMap<String, NonZeroU32>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ComplexParam {
     #[serde(default)]
     pub array: Vec<u32>,
@@ -83,17 +83,13 @@ impl de::WellKnown for ComplexParam {
     const DE: Self::Deserializer = de::Serde![object];
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct SecretKey(pub H256);
 
 impl fmt::Debug for SecretKey {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.debug_tuple("SecretKey").field(&"_").finish()
-    }
-}
-
-impl<'de> Deserialize<'de> for SecretKey {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        H256::deserialize(deserializer).map(Self)
     }
 }
 

--- a/crates/smart-config-commands/src/debug.rs
+++ b/crates/smart-config-commands/src/debug.rs
@@ -9,7 +9,7 @@ use anstyle::{AnsiColor, Color, Style};
 use smart_config::{
     metadata::ConfigMetadata,
     value::{FileFormat, StrValue, Value, ValueOrigin, WithOrigin},
-    visit::ConfigVisitor,
+    visit::{ConfigVisitor, VisitConfig},
     ConfigRepository, ParseError,
 };
 
@@ -71,6 +71,10 @@ impl ConfigVisitor for ParamValuesVisitor {
             param.deserializer.serialize_param(value)
         };
         self.param_values.insert(param_index, json);
+    }
+
+    fn visit_nested_config(&mut self, _config_index: usize, _config: &dyn VisitConfig) {
+        // Don't recurse into nested configs, we debug them separately
     }
 }
 

--- a/crates/smart-config-commands/src/help.rs
+++ b/crates/smart-config-commands/src/help.rs
@@ -7,14 +7,16 @@ use smart_config::{
     ConfigRef, ConfigSchema,
 };
 
-use crate::{ParamRef, Printer, CONFIG_PATH, STRING};
+use crate::{
+    utils::{write_json_value, STRING},
+    ParamRef, Printer, CONFIG_PATH,
+};
 
 const INDENT: &str = "  ";
 const DIMMED: Style = Style::new().dimmed();
 const MAIN_NAME: Style = Style::new().bold();
 const DEFAULT_VARIANT: Style = Style::new().bold();
 const FIELD: Style = Style::new().underline();
-const DEFAULT_VAL: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
 const UNIT: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan)));
 const SECRET: Style = Style::new()
     .bg_color(Some(Color::Ansi(AnsiColor::Cyan)))
@@ -169,10 +171,10 @@ impl ParamRef<'_> {
         }
 
         if let Some(default) = self.param.default_value() {
-            writeln!(
-                writer,
-                "{INDENT}{FIELD}Default{FIELD:#}: {DEFAULT_VAL}{default:?}{DEFAULT_VAL:#}"
-            )?;
+            write!(writer, "{INDENT}{FIELD}Default{FIELD:#}: ")?;
+            let default_json = self.param.deserializer.serialize_param(default.as_ref());
+            write_json_value(writer, &default_json, 2)?;
+            writeln!(writer)?;
         }
         if let Some(fallback) = self.param.fallback {
             write!(writer, "{INDENT}{FIELD}Fallbacks{FIELD:#}: ")?;

--- a/crates/smart-config-commands/src/lib.rs
+++ b/crates/smart-config-commands/src/lib.rs
@@ -59,9 +59,9 @@ use smart_config::{metadata::ParamMetadata, ConfigRef};
 
 mod debug;
 mod help;
+mod utils;
 
 const CONFIG_PATH: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
-const STRING: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan)));
 
 /// Wrapper around an I/O writer. Will style the output with ANSI sequences if appropriate.
 ///

--- a/crates/smart-config-commands/src/utils.rs
+++ b/crates/smart-config-commands/src/utils.rs
@@ -1,0 +1,86 @@
+//! Functionality shared by multiple CLI commands.
+
+use std::io;
+
+use anstyle::{AnsiColor, Color, Style};
+use smart_config::value::{StrValue, Value, WithOrigin};
+
+pub(crate) const STRING: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan)));
+const NULL: Style = Style::new().bold();
+const BOOL: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)));
+const NUMBER: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
+const SECRET: Style = Style::new()
+    .bg_color(Some(Color::Ansi(AnsiColor::Cyan)))
+    .fg_color(None);
+const OBJECT_KEY: Style = Style::new().bold();
+
+pub(crate) fn write_json_value(
+    writer: &mut impl io::Write,
+    value: &serde_json::Value,
+    ident: usize,
+) -> io::Result<()> {
+    match value {
+        serde_json::Value::Null => write!(writer, "{NULL}null{NULL:#}"),
+        serde_json::Value::Bool(val) => write!(writer, "{BOOL}{val:?}{BOOL:#}"),
+        serde_json::Value::Number(val) => write!(writer, "{NUMBER}{val}{NUMBER:#}"),
+        serde_json::Value::String(val) => write!(writer, "{STRING}{val:?}{STRING:#}"),
+        serde_json::Value::Array(val) => {
+            if val.is_empty() {
+                write!(writer, "[]")
+            } else {
+                writeln!(writer, "[")?;
+                for item in val {
+                    write!(writer, "{:ident$}  ", "")?;
+                    write_json_value(writer, item, ident + 2)?;
+                    writeln!(writer, ",")?;
+                }
+                write!(writer, "{:ident$}]", "")
+            }
+        }
+        serde_json::Value::Object(val) => {
+            if val.is_empty() {
+                write!(writer, "{{}}")
+            } else {
+                writeln!(writer, "{{")?;
+                for (key, value) in val {
+                    write!(writer, "{:ident$}  {OBJECT_KEY}{key:?}{OBJECT_KEY:#}: ", "")?;
+                    write_json_value(writer, value, ident + 2)?;
+                    writeln!(writer, ",")?;
+                }
+                write!(writer, "{:ident$}}}", "")
+            }
+        }
+    }
+}
+
+pub(crate) fn write_value(
+    writer: &mut impl io::Write,
+    value: &WithOrigin,
+    ident: usize,
+) -> io::Result<()> {
+    match &value.inner {
+        Value::Null => write!(writer, "{NULL}null{NULL:#}"),
+        Value::Bool(val) => write!(writer, "{BOOL}{val:?}{BOOL:#}"),
+        Value::Number(val) => write!(writer, "{NUMBER}{val}{NUMBER:#}"),
+        Value::String(StrValue::Plain(val)) => write!(writer, "{STRING}{val:?}{STRING:#}"),
+        Value::String(StrValue::Secret(_)) => write!(writer, "{SECRET}[REDACTED]{SECRET:#}"),
+        Value::Array(val) => {
+            writeln!(writer, "[")?;
+            for item in val {
+                write!(writer, "{:ident$}  ", "")?;
+                write_value(writer, item, ident + 2)?;
+                writeln!(writer, ",")?;
+            }
+            write!(writer, "{:ident$}]", "")
+        }
+        Value::Object(val) => {
+            writeln!(writer, "{{")?;
+            for (key, value) in val {
+                write!(writer, "{:ident$}  {OBJECT_KEY}{key:?}{OBJECT_KEY:#}: ", "")?;
+                write_value(writer, value, ident + 2)?;
+                writeln!(writer, ",")?;
+            }
+            write!(writer, "{:ident$}}}", "")
+        }
+    }
+}

--- a/crates/smart-config/src/de/_private.rs
+++ b/crates/smart-config/src/de/_private.rs
@@ -114,4 +114,8 @@ impl DeserializeParam<&'static str> for TagDeserializer {
                 ErrorWithOrigin::json(err, origin)
             })
     }
+
+    fn serialize_param(&self, &param: &&'static str) -> serde_json::Value {
+        param.into()
+    }
 }

--- a/crates/smart-config/src/de/macros.rs
+++ b/crates/smart-config/src/de/macros.rs
@@ -87,33 +87,4 @@ macro_rules! Serde {
     };
 }
 
-/// Constructor of [`Custom`](struct@crate::de::Custom) types / instances.
-///
-/// The macro accepts a deserialized type followed by a comma-separated list of expected basic types from the following set: `bool`, `int`,
-/// `float`, `str`, `array`, `object`. As a shortcut, `Custom![_; *]` signals to accept any input.
-///
-/// # Examples
-///
-/// ```
-/// use serde::Deserialize;
-/// use smart_config::de::Custom;
-///
-/// /// Deserializer that accepts a string and maps it to its length.
-/// const LEN_DESERIALIZER: Custom![usize; str] = Custom![_; str](|ctx, param| {
-///     let de = ctx.current_value_deserializer(param.name)?;
-///     Ok(String::deserialize(de)?.len())
-/// });
-/// ```
-#[macro_export]
-#[allow(non_snake_case)]
-macro_rules! Custom {
-    ($typ:ty; *) => {
-        $crate::de::Custom::<$typ, { $crate::metadata::BasicTypes::ANY.raw() }>
-    };
-    ($typ:ty; $($expecting:tt),+ $(,)?) => {
-        $crate::de::Custom::<$typ, { $crate::_basic_types!($($expecting)+) }>
-    };
-}
-
-pub use Custom;
 pub use Serde;

--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -56,10 +56,8 @@ use serde::de::Error as DeError;
 use self::deserializer::ValueDeserializer;
 pub use self::{
     deserializer::DeserializerOptions,
-    macros::{Custom, Serde},
-    param::{
-        Custom, DeserializeParam, Optional, OrString, Qualified, Serde, WellKnown, WithDefault,
-    },
+    macros::Serde,
+    param::{DeserializeParam, Optional, OrString, Qualified, Serde, WellKnown, WithDefault},
     repeated::{Delimited, Entries, NamedEntries, Repeated},
     secret::{FromSecretString, Secret},
     units::WithUnit,

--- a/crates/smart-config/src/de/param.rs
+++ b/crates/smart-config/src/de/param.rs
@@ -170,43 +170,6 @@ impl<T: Serialize + DeserializeOwned, const EXPECTING: u8> DeserializeParam<T>
     }
 }
 
-type DeserializeFn<T> =
-    fn(DeserializeContext<'_>, &'static ParamMetadata) -> Result<T, ErrorWithOrigin>;
-
-/// Custom deserializer for a specific type. Usually created with the help of [`Custom!`](crate::Custom!) macro;
-/// see its docs for the examples of usage.
-pub struct Custom<T, const EXPECTING: u8>(pub DeserializeFn<T>);
-
-impl<T: 'static, const EXPECTING: u8> fmt::Debug for Custom<T, EXPECTING> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("Custom")
-            .field("type", &any::type_name::<T>())
-            .field("expecting", &BasicTypes::from_raw(EXPECTING))
-            .finish()
-    }
-}
-
-impl<T: 'static, const EXPECTING: u8> DeserializeParam<T> for Custom<T, EXPECTING> {
-    const EXPECTING: BasicTypes = BasicTypes::from_raw(EXPECTING);
-
-    fn describe(&self, _description: &mut TypeDescription) {
-        // Do nothing
-    }
-
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<T, ErrorWithOrigin> {
-        self.0(ctx, param)
-    }
-
-    fn serialize_param(&self, _param: &T) -> serde_json::Value {
-        todo!()
-    }
-}
-
 impl WellKnown for bool {
     type Deserializer = super::Serde![bool];
     const DE: Self::Deserializer = super::Serde![bool];

--- a/crates/smart-config/src/de/param.rs
+++ b/crates/smart-config/src/de/param.rs
@@ -47,7 +47,10 @@ pub trait DeserializeParam<T>: fmt::Debug + Send + Sync + 'static {
     const EXPECTING: BasicTypes;
 
     /// Additional info about the deserialized type, e.g., extended description.
-    fn describe(&self, description: &mut TypeDescription);
+    #[allow(unused)]
+    fn describe(&self, description: &mut TypeDescription) {
+        // Do nothing
+    }
 
     /// Performs deserialization given the context and param metadata.
     ///

--- a/crates/smart-config/src/de/param.rs
+++ b/crates/smart-config/src/de/param.rs
@@ -63,7 +63,10 @@ pub trait DeserializeParam<T>: fmt::Debug + Send + Sync + 'static {
         param: &'static ParamMetadata,
     ) -> Result<T, ErrorWithOrigin>;
 
-    /// FIXME
+    /// Serializes the provided parameter to the JSON model.
+    ///
+    /// Serialization is considered infallible (`serde_json` serialization may fail on recursive or very deeply nested data types;
+    /// please don't use such data types for config params).
     fn serialize_param(&self, param: &T) -> serde_json::Value;
 }
 

--- a/crates/smart-config/src/de/primitive_types_impl.rs
+++ b/crates/smart-config/src/de/primitive_types_impl.rs
@@ -1,4 +1,4 @@
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     de::{DeserializeContext, DeserializeParam, Qualified, Serde, WellKnown},
@@ -31,7 +31,7 @@ impl_well_known_hash!(H128, H160, H256, H384, H512, H768);
 pub struct HexUintDeserializer;
 
 // This implementation is overly general, but since the struct is private, it's OK.
-impl<T: DeserializeOwned> DeserializeParam<T> for HexUintDeserializer {
+impl<T: Serialize + DeserializeOwned> DeserializeParam<T> for HexUintDeserializer {
     const EXPECTING: BasicTypes = BasicTypes::STRING;
 
     fn describe(&self, description: &mut TypeDescription) {
@@ -50,6 +50,10 @@ impl<T: DeserializeOwned> DeserializeParam<T> for HexUintDeserializer {
             }
         }
         T::deserialize(deserializer)
+    }
+
+    fn serialize_param(&self, param: &T) -> serde_json::Value {
+        serde_json::to_value(param).expect("failed serializing value")
     }
 }
 

--- a/crates/smart-config/src/de/repeated.rs
+++ b/crates/smart-config/src/de/repeated.rs
@@ -73,6 +73,26 @@ impl<De> Repeated<De> {
     }
 }
 
+macro_rules! impl_serialization_for_repeated {
+    ($param:ty) => {
+        fn deserialize_param(
+            &self,
+            ctx: DeserializeContext<'_>,
+            param: &'static ParamMetadata,
+        ) -> Result<$param, ErrorWithOrigin> {
+            self.deserialize_array(ctx, param, None)
+        }
+
+        fn serialize_param(&self, param: &$param) -> serde_json::Value {
+            let array = param
+                .iter()
+                .map(|item| self.0.serialize_param(item))
+                .collect();
+            serde_json::Value::Array(array)
+        }
+    };
+}
+
 impl<T: 'static, De> DeserializeParam<Vec<T>> for Repeated<De>
 where
     De: DeserializeParam<T>,
@@ -83,13 +103,7 @@ where
         description.set_items(&self.0);
     }
 
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<Vec<T>, ErrorWithOrigin> {
-        self.deserialize_array(ctx, param, None)
-    }
+    impl_serialization_for_repeated!(Vec<T>);
 }
 
 impl<T, S, De> DeserializeParam<HashSet<T, S>> for Repeated<De>
@@ -104,13 +118,7 @@ where
         description.set_details("set").set_items(&self.0);
     }
 
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<HashSet<T, S>, ErrorWithOrigin> {
-        self.deserialize_array(ctx, param, None)
-    }
+    impl_serialization_for_repeated!(HashSet<T, S>);
 }
 
 impl<T, De> DeserializeParam<BTreeSet<T>> for Repeated<De>
@@ -124,13 +132,7 @@ where
         description.set_details("set").set_items(&self.0);
     }
 
-    fn deserialize_param(
-        &self,
-        ctx: DeserializeContext<'_>,
-        param: &'static ParamMetadata,
-    ) -> Result<BTreeSet<T>, ErrorWithOrigin> {
-        self.deserialize_array(ctx, param, None)
-    }
+    impl_serialization_for_repeated!(BTreeSet<T>);
 }
 
 impl<T: 'static, De, const N: usize> DeserializeParam<[T; N]> for Repeated<De>
@@ -153,6 +155,14 @@ where
         let items: Vec<_> = self.deserialize_array(ctx, param, Some(N))?;
         // `unwrap()` is safe due to the length check in `deserialize_inner()`
         Ok(items.try_into().ok().unwrap())
+    }
+
+    fn serialize_param(&self, param: &[T; N]) -> serde_json::Value {
+        let array = param
+            .iter()
+            .map(|item| self.0.serialize_param(item))
+            .collect();
+        serde_json::Value::Array(array)
     }
 }
 
@@ -305,6 +315,7 @@ where
     DeK: DeserializeParam<K>,
     DeV: DeserializeParam<V>,
     C: FromIterator<(K, V)>,
+    for<'a> &'a C: IntoIterator<Item = (&'a K, &'a V)>, // FIXME: not necessarily true (e.g., for Vec)
 {
     const EXPECTING: BasicTypes = {
         assert!(
@@ -331,6 +342,22 @@ where
             return Err(deserializer.invalid_type("object"));
         };
         self.deserialize_map(ctx, param, map, deserializer.origin())
+    }
+
+    fn serialize_param(&self, param: &C) -> serde_json::Value {
+        let object = param
+            .into_iter()
+            .map(|(key, value)| {
+                let key = match self.keys.serialize_param(key) {
+                    serde_json::Value::String(s) => s,
+                    serde_json::Value::Number(num) => num.to_string(),
+                    _ => panic!("unsupported key value"),
+                };
+                let value = self.values.serialize_param(value);
+                (key, value)
+            })
+            .collect();
+        serde_json::Value::Object(object)
     }
 }
 
@@ -455,6 +482,10 @@ impl<T: DeserializeOwned + WellKnown> DeserializeParam<T> for Delimited {
         });
         let array = WithOrigin::new(Value::Array(array_items.collect()), array_origin);
         T::DE.deserialize_param(ctx.patched(&array), param)
+    }
+
+    fn serialize_param(&self, param: &T) -> serde_json::Value {
+        T::DE.serialize_param(param)
     }
 }
 
@@ -612,6 +643,7 @@ where
     DeK: DeserializeParam<K>,
     DeV: DeserializeParam<V>,
     C: FromIterator<(K, V)>,
+    for<'a> &'a C: IntoIterator<Item = (&'a K, &'a V)>, // FIXME: not necessarily true (e.g., for Vec)
 {
     const EXPECTING: BasicTypes = BasicTypes::OBJECT.or(BasicTypes::ARRAY);
 
@@ -641,5 +673,9 @@ where
             }
             _ => Err(deserializer.invalid_type("object or array")),
         }
+    }
+
+    fn serialize_param(&self, param: &C) -> serde_json::Value {
+        self.inner.serialize_param(param)
     }
 }

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -244,12 +244,37 @@ fn parsing_compound_config() {
         }
     );
     assert_eq!(
-        config.nested_opt.unwrap(),
+        *config.nested_opt.as_ref().unwrap(),
         NestedConfig {
             simple_enum: SimpleEnum::Second,
             other_int: 42,
             map: HashMap::new(),
         }
+    );
+
+    let json = test_config_roundtrip(&config);
+    assert_eq!(
+        serde_json::Value::from(json),
+        serde_json::json!({
+            "default": {
+                "map": { "foo": 3 },
+                "other_int": 42,
+                "renamed": "second",
+            },
+            "nested": {
+                "map": {},
+                "other_int": 321,
+                "renamed": "first",
+            },
+            "nested_opt": {
+                "map": {},
+                "other_int": 42,
+                "renamed": "second",
+            },
+            "map": {},
+            "other_int": 42,
+            "renamed": "second",
+        })
     );
 }
 

--- a/crates/smart-config/src/de/units.rs
+++ b/crates/smart-config/src/de/units.rs
@@ -308,6 +308,11 @@ impl DeserializeParam<Duration> for WithUnit {
     }
 
     fn serialize_param(&self, param: &Duration) -> serde_json::Value {
+        if param.is_zero() {
+            // Special case to produce more "expected" string.
+            return "0s".into();
+        }
+
         let duration_string = if param.subsec_millis() != 0 {
             format!("{}ms", param.as_millis())
         } else {
@@ -494,5 +499,63 @@ mod tests {
         assert_eq!(size, RawByteSize::Megabytes(4));
         let size: RawByteSize = "1 GB".parse().unwrap();
         assert_eq!(size, RawByteSize::Gigabytes(1));
+    }
+
+    #[test]
+    fn serializing_with_time_unit() {
+        let val = TimeUnit::Millis.serialize_param(&Duration::from_millis(10));
+        assert_eq!(val, 10_u32);
+        let val = TimeUnit::Millis.serialize_param(&Duration::from_secs(10));
+        assert_eq!(val, 10_000_u32);
+        let val = TimeUnit::Seconds.serialize_param(&Duration::from_secs(10));
+        assert_eq!(val, 10_u32);
+        let val = TimeUnit::Minutes.serialize_param(&Duration::from_secs(10));
+        assert_eq!(val, 0_u32);
+        let val = TimeUnit::Minutes.serialize_param(&Duration::from_secs(120));
+        assert_eq!(val, 2_u32);
+    }
+
+    #[test]
+    fn serializing_with_size_unit() {
+        let val = SizeUnit::Bytes.serialize_param(&ByteSize(128));
+        assert_eq!(val, 128_u32);
+        let val = SizeUnit::Bytes.serialize_param(&ByteSize(1 << 16));
+        assert_eq!(val, 1_u32 << 16);
+        let val = SizeUnit::KiB.serialize_param(&ByteSize(1 << 16));
+        assert_eq!(val, 1_u32 << 6);
+        let val = SizeUnit::MiB.serialize_param(&ByteSize(1 << 16));
+        assert_eq!(val, 0_u32);
+        let val = SizeUnit::MiB.serialize_param(&ByteSize::new(3, SizeUnit::MiB));
+        assert_eq!(val, 3_u32);
+    }
+
+    #[test]
+    fn serializing_with_duration() {
+        let val = WithUnit.serialize_param(&Duration::ZERO);
+        assert_eq!(val, "0s");
+        let val = WithUnit.serialize_param(&Duration::from_millis(10));
+        assert_eq!(val, "10ms");
+        let val = WithUnit.serialize_param(&Duration::from_secs(5));
+        assert_eq!(val, "5s");
+        let val = WithUnit.serialize_param(&Duration::from_millis(5_050));
+        assert_eq!(val, "5050ms");
+        let val = WithUnit.serialize_param(&Duration::from_secs(300));
+        assert_eq!(val, "5min");
+        let val = WithUnit.serialize_param(&Duration::from_secs(7_200));
+        assert_eq!(val, "2h");
+        let val = WithUnit.serialize_param(&Duration::from_secs(86_400));
+        assert_eq!(val, "1d");
+    }
+
+    #[test]
+    fn serializing_with_byte_size() {
+        let val = WithUnit.serialize_param(&ByteSize(0));
+        assert_eq!(val, "0 B");
+        let val = WithUnit.serialize_param(&ByteSize(128));
+        assert_eq!(val, "128 B");
+        let val = WithUnit.serialize_param(&ByteSize(32 << 10));
+        assert_eq!(val, "32 KiB");
+        let val = WithUnit.serialize_param(&ByteSize(3 << 20));
+        assert_eq!(val, "3 MiB");
     }
 }

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -85,14 +85,14 @@ pub struct ParamMetadata {
     #[doc(hidden)] // implementation detail
     pub deserializer: &'static dyn ErasedDeserializer,
     #[doc(hidden)] // implementation detail
-    pub default_value: Option<fn() -> Box<dyn fmt::Debug>>,
+    pub default_value: Option<fn() -> Box<dyn any::Any>>,
     #[doc(hidden)]
     pub fallback: Option<&'static dyn FallbackSource>,
 }
 
 impl ParamMetadata {
     /// Returns the default value for the param.
-    pub fn default_value(&self) -> Option<impl fmt::Debug + '_> {
+    pub fn default_value(&self) -> Option<Box<dyn any::Any>> {
         self.default_value.map(|value_fn| value_fn())
     }
 

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::Context as _;
 use assert_matches::assert_matches;
 use secrecy::{ExposeSecret, SecretString};
-use serde::{de::Error as DeError, Deserialize};
+use serde::{de::Error as DeError, Deserialize, Serialize};
 
 use crate::{
     de::{self, DeserializeContext, DeserializerOptions, Serde, WellKnown},
@@ -25,7 +25,7 @@ use crate::{
     ParseErrors,
 };
 
-#[derive(Debug, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum SimpleEnum {
     #[serde(alias = "first_choice")]
@@ -38,7 +38,7 @@ impl WellKnown for SimpleEnum {
     const DE: Self::Deserializer = Serde![str];
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TestParam {
     pub int: u64,
     #[serde(default)]
@@ -175,7 +175,7 @@ pub(crate) enum DefaultingEnumConfig {
     },
 }
 
-#[derive(Debug, Default, PartialEq, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub(crate) struct MapOrString(pub HashMap<String, u64>);
 

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -272,6 +272,8 @@ pub(crate) struct ComposedConfig {
     pub map_of_ints: HashMap<u64, Duration>,
     #[config(default, with = de::Entries::WELL_KNOWN.named("val", "timeout"))]
     pub entry_map: HashMap<u64, Duration>,
+    #[config(default, with = de::Entries::WELL_KNOWN.named("method", "priority"))]
+    pub entry_slice: Box<[(String, i32)]>,
 }
 
 #[derive(Debug, DescribeConfig, DeserializeConfig)]
@@ -442,13 +444,14 @@ pub(crate) fn serialize_to_json<C: DeserializeConfig>(
     visitor.json
 }
 
-pub(crate) fn test_config_roundtrip<C>(config: &C)
+pub(crate) fn test_config_roundtrip<C>(config: &C) -> serde_json::Map<String, serde_json::Value>
 where
     C: DeserializeConfig + PartialEq + fmt::Debug,
 {
     let json = serialize_to_json(config);
-    let config_copy: C = testing::test(Json::new("test.json", json)).unwrap();
+    let config_copy: C = testing::test(Json::new("test.json", json.clone())).unwrap();
     assert_eq!(config_copy, *config);
+    json
 }
 
 #[cfg(test)]

--- a/crates/smart-config/src/types.rs
+++ b/crates/smart-config/src/types.rs
@@ -17,7 +17,9 @@ impl fmt::Debug for ByteSize {
 
 impl fmt::Display for ByteSize {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.0 % (1 << 30) == 0 {
+        if self.0 == 0 {
+            formatter.write_str("0 B")
+        } else if self.0 % (1 << 30) == 0 {
             write!(formatter, "{} GiB", self.0 >> 30)
         } else if self.0 % (1 << 20) == 0 {
             write!(formatter, "{} MiB", self.0 >> 20)

--- a/crates/smart-config/src/visit.rs
+++ b/crates/smart-config/src/visit.rs
@@ -1,11 +1,6 @@
 //! Visitor pattern for configs.
 
-use std::{any, fmt};
-
-/// Types that can be used as configuration parameters. Automatically implemented.
-pub trait ParamValue: any::Any + fmt::Debug {}
-
-impl<T: any::Any + fmt::Debug> ParamValue for T {}
+use std::any;
 
 /// Visitor of configuration parameters in a particular configuration.
 #[doc(hidden)] // API is not stable yet
@@ -16,7 +11,7 @@ pub trait ConfigVisitor {
 
     /// Visits a parameter providing its value for inspection. This will be called for all params in a struct config,
     /// and for params associated with the active tag variant in an enum config.
-    fn visit_param(&mut self, param_index: usize, value: &dyn ParamValue);
+    fn visit_param(&mut self, param_index: usize, value: &dyn any::Any);
 }
 
 /// Configuration that can be visited (e.g., to inspect its parameters in a generic way).
@@ -42,7 +37,7 @@ mod tests {
     struct PersistingVisitor {
         metadata: &'static ConfigMetadata,
         tag: Option<&'static str>,
-        param_values: HashMap<&'static str, String>,
+        param_values: HashMap<&'static str, serde_json::Value>,
     }
 
     impl PersistingVisitor {
@@ -61,9 +56,11 @@ mod tests {
             self.tag = Some(self.metadata.tag.unwrap().variants[variant_index].rust_name);
         }
 
-        fn visit_param(&mut self, param_index: usize, value: &dyn ParamValue) {
+        fn visit_param(&mut self, param_index: usize, value: &dyn any::Any) {
             let param = &self.metadata.params[param_index];
-            let prev_value = self.param_values.insert(param.name, format!("{value:?}"));
+            let prev_value = self
+                .param_values
+                .insert(param.name, param.deserializer.serialize_param(value));
             assert!(
                 prev_value.is_none(),
                 "Param value {} is visited twice",
@@ -82,10 +79,10 @@ mod tests {
         assert_eq!(
             visitor.param_values,
             HashMap::from([
-                ("float", "None".to_owned()),
-                ("set", "{}".to_owned()),
-                ("int", "12".to_owned()),
-                ("url", "Some(\"https://example.com/\")".to_owned())
+                ("float", serde_json::Value::Null),
+                ("set", serde_json::json!([])),
+                ("int", 12_u32.into()),
+                ("url", "https://example.com/".into())
             ])
         );
     }
@@ -115,9 +112,9 @@ mod tests {
         assert_eq!(
             visitor.param_values,
             HashMap::from([
-                ("string", "Some(\"test\")".to_owned()),
-                ("flag", "true".to_owned()),
-                ("set", "{1}".to_owned())
+                ("string", "test".into()),
+                ("flag", true.into()),
+                ("set", serde_json::json!([1]))
             ])
         );
     }


### PR DESCRIPTION
# What ❔

Allows serializing config params to the JSON object model.

## Why ❔

This is useful to inspect config params using the visitor pattern, and simplifies handling defaults.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.