### PR TITLE
feat: Derive example configs

### DIFF
--- a/crates/smart-config-commands/Cargo.toml
+++ b/crates/smart-config-commands/Cargo.toml
@@ -14,6 +14,7 @@ description = "Command-line extensions for `smart-config` library"
 anstream.workspace = true
 anstyle.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 smart-config.workspace = true
 
 [dev-dependencies]
@@ -23,7 +24,6 @@ clap = { workspace = true, features = ["derive"] }
 doc-comment.workspace = true
 primitive-types.workspace = true
 serde.workspace = true
-serde_yaml.workspace = true
 version-sync.workspace = true
 
 [lints]

--- a/crates/smart-config-commands/README.md
+++ b/crates/smart-config-commands/README.md
@@ -66,6 +66,13 @@ The output will contain deserialization errors for all available params:
 
 ![Example output for print_debug](examples/errors.svg)
 
+### Outputting JSON / YAML
+
+The library can fancy-print JSON and YAML. This be used together with `smart-config` tooling to produce default / example configs,
+diffs with default param values etc. See [the example](examples/cli.rs) for a couple of use cases.
+
+![Example of fancy-printed YAML](examples/ser-yaml.svg)
+
 ## License
 
 Distributed under the terms of either

--- a/crates/smart-config-commands/examples/cli.rs
+++ b/crates/smart-config-commands/examples/cli.rs
@@ -289,6 +289,9 @@ enum Cli {
         /// Use example config instead of parsing sources.
         #[arg(long)]
         example: bool,
+        /// Do not output default param values.
+        #[arg(long)]
+        diff: bool,
         /// Serialization format.
         #[arg(long, value_enum, default_value_t = SerializationFormat::Yaml)]
         format: SerializationFormat,
@@ -332,16 +335,20 @@ fn main() {
                 process::exit(1);
             }
         }
-        Cli::Serialize { example, format } => {
+        Cli::Serialize {
+            example,
+            diff,
+            format,
+        } => {
             let (json, original_config) = if example {
                 let example_config = TestConfig::example_config();
-                let json = serialize_to_json(&example_config);
+                let json = serialize_to_json(&example_config, diff);
                 // Need to wrap the serialized value with the 'test' prefix so that it corresponds to the schema.
                 (serde_json::json!({ "test": json }), example_config)
             } else {
                 let repo = create_mock_repo(&schema, false);
                 let original_config: TestConfig = repo.single().unwrap().parse().unwrap();
-                (repo.canonicalize().unwrap().into(), original_config)
+                (repo.canonicalize(diff).unwrap().into(), original_config)
             };
 
             let mut buffer = vec![];

--- a/crates/smart-config-commands/examples/cli.rs
+++ b/crates/smart-config-commands/examples/cli.rs
@@ -51,6 +51,7 @@ pub struct TestConfig {
     #[config(nest, alias = "funds")]
     pub funding: Option<FundingConfig>,
     /// Required param.
+    #[config(example = 42)]
     pub required: u64,
     #[config(nest)]
     pub object_store: ObjectStoreConfig,

--- a/crates/smart-config-commands/examples/cli.rs
+++ b/crates/smart-config-commands/examples/cli.rs
@@ -16,16 +16,16 @@ use smart_config::{
     metadata::{SizeUnit, TimeUnit},
     validation::NotEmpty,
     value::SecretString,
-    ByteSize, ConfigRepository, ConfigSchema, DescribeConfig, DeserializeConfig, Environment, Json,
-    Prefixed, Yaml,
+    ByteSize, ConfigRepository, ConfigSchema, DescribeConfig, DeserializeConfig, Environment,
+    ExampleConfig, Json, Prefixed, Yaml,
 };
 use smart_config_commands::{ParamRef, Printer};
 
 /// Configuration with type params of several types.
-#[derive(Debug, DescribeConfig, DeserializeConfig)]
+#[derive(Debug, DescribeConfig, DeserializeConfig, ExampleConfig)]
 pub struct TestConfig {
     /// Port to bind to.
-    #[config(default_t = 8080, alias = "bind_to")]
+    #[config(example = 8080, alias = "bind_to")]
     pub port: u16,
     /// Application name.
     #[config(default_t = "app".into(), validate(NotEmpty))]
@@ -96,7 +96,7 @@ impl fmt::Debug for SecretKey {
     }
 }
 
-#[derive(Debug, DescribeConfig, DeserializeConfig)]
+#[derive(Debug, DescribeConfig, DeserializeConfig, ExampleConfig)]
 #[config(validate(
     Self::validate_address,
     "`address` should be non-zero for non-zero `balance`"
@@ -109,9 +109,11 @@ pub struct FundingConfig {
     #[config(default)]
     pub balance: U256,
     /// Secret string value.
+    #[config(example = Some("correct horse battery staple".into()))]
     pub api_key: Option<SecretString>,
     /// Secret key.
     #[config(secret, with = de::Optional(de::Serde![str]))]
+    #[config(example = Some(SecretKey(H256::zero())))]
     pub secret_key: Option<SecretKey>,
 }
 
@@ -122,7 +124,7 @@ impl FundingConfig {
 }
 
 #[derive(Debug, DescribeConfig, DeserializeConfig)]
-#[config(tag = "type", rename_all = "snake_case")]
+#[config(derive(Default), tag = "type", rename_all = "snake_case")]
 pub enum ObjectStoreConfig {
     /// Stores object locally as files.
     #[config(default)]

--- a/crates/smart-config-commands/examples/make-snapshots.sh
+++ b/crates/smart-config-commands/examples/make-snapshots.sh
@@ -15,7 +15,7 @@ term-transcript --version
 
 echo "Building CLI example..."
 cargo build -p smart-config-commands --example cli
-if [[ ! -x "$TARGET_DIR/examples/cli" ]]; then
+if [ ! -x "$TARGET_DIR/examples/cli" ]; then
   echo "Example executable not found at expected location"
   exit 1
 fi
@@ -29,3 +29,5 @@ echo "Creating debug snapshot..."
 term-transcript exec $TT_ARGS --scroll=540 "$TARGET_DIR/examples/cli debug" > "$THIS_DIR/debug.svg"
 echo "Creating errors snapshot..."
 term-transcript exec $TT_ARGS --scroll=540 "$TARGET_DIR/examples/cli debug --bogus" > "$THIS_DIR/errors.svg"
+echo "Create YAML serialization snapshot..."
+term-transcript exec $TT_ARGS "$TARGET_DIR/examples/cli serialize --diff" > "$THIS_DIR/ser-yaml.svg"

--- a/crates/smart-config-commands/examples/ser-yaml.svg
+++ b/crates/smart-config-commands/examples/ser-yaml.svg
@@ -1,0 +1,78 @@
+<!-- Created with term-transcript v0.4.0-beta.1 (https://github.com/slowli/term-transcript) -->
+<svg viewBox="0 -22 860 618" width="860" height="618" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .container {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      line-height: 18px;
+    }
+    .input,.output,.output-bg {
+      white-space: pre;
+    }
+    .input-bg { fill: #fff; fill-opacity: 0.1; }
+    .output-bg { user-select: none; text-rendering: geometricPrecision; stroke-width: 0.1; }
+    .line-numbers { text-anchor: end; fill-opacity: 0.35; user-select: none; }
+
+    .bold,.prompt { font-weight: 600; }
+    .italic { font-style: italic; }
+    .underline { text-decoration: underline; }
+    .dimmed { fill-opacity: 0.7; }
+    .fg0 { fill: #010101; } .output-bg .fg0 { stroke: #010101; }
+    .fg1 { fill: #de382b; } .output-bg .fg1 { stroke: #de382b; }
+    .fg2 { fill: #38b54a; } .output-bg .fg2 { stroke: #38b54a; }
+    .fg3 { fill: #ffc706; } .output-bg .fg3 { stroke: #ffc706; }
+    .fg4 { fill: #006fb8; } .output-bg .fg4 { stroke: #006fb8; }
+    .fg5 { fill: #762671; } .output-bg .fg5 { stroke: #762671; }
+    .fg6 { fill: #2cb5e9; } .output-bg .fg6 { stroke: #2cb5e9; }
+    .fg7 { fill: #cccccc; } .output-bg .fg7 { stroke: #cccccc; }
+    .fg8 { fill: #808080; } .output-bg .fg8 { stroke: #808080; }
+    .fg9 { fill: #ff0000; } .output-bg .fg9 { stroke: #ff0000; }
+    .fg10 { fill: #00ff00; } .output-bg .fg10 { stroke: #00ff00; }
+    .fg11 { fill: #ffff00; } .output-bg .fg11 { stroke: #ffff00; }
+    .fg12 { fill: #0000ff; } .output-bg .fg12 { stroke: #0000ff; }
+    .fg13 { fill: #ff00ff; } .output-bg .fg13 { stroke: #ff00ff; }
+    .fg14 { fill: #00ffff; } .output-bg .fg14 { stroke: #00ffff; }
+    .fg15 { fill: #ffffff; } .output-bg .fg15 { stroke: #ffffff; }
+  </style>
+  <rect width="100%" height="100%" y="-22" rx="4.5" style="fill: #010101;" />
+  <rect width="100%" height="26" y="-22" clip-path="inset(0 0 -10 0 round 4.5)" style="fill: #fff; fill-opacity: 0.1;"/>
+  <circle cx="17" cy="-9" r="7" style="fill: #de382b;"/>
+  <circle cx="37" cy="-9" r="7" style="fill: #ffc706;"/>
+  <circle cx="57" cy="-9" r="7" style="fill: #38b54a;"/>
+    <svg x="0" y="10" width="860" height="576" viewBox="0 0 860 576">
+      <g class="input-bg"></g>
+      <text class="container fg7 line-numbers"><tspan x="34" y="14">1</tspan><tspan x="34" y="32">2</tspan><tspan x="34" y="50">3</tspan><tspan x="34" y="68">4</tspan><tspan x="34" y="86">5</tspan><tspan x="34" y="104">6</tspan><tspan x="34" y="122">7</tspan><tspan x="34" y="140">8</tspan><tspan x="34" y="158">9</tspan><tspan x="34" y="176">10</tspan><tspan x="34" y="194">11</tspan><tspan x="34" y="212">12</tspan><tspan x="34" y="230">13</tspan><tspan x="34" y="248">14</tspan><tspan x="34" y="266">15</tspan><tspan x="34" y="284">16</tspan><tspan x="34" y="302">17</tspan><tspan x="34" y="320">18</tspan><tspan x="34" y="338">19</tspan><tspan x="34" y="356">20</tspan><tspan x="34" y="374">21</tspan><tspan x="34" y="392">22</tspan><tspan x="34" y="410">23</tspan><tspan x="34" y="428">24</tspan><tspan x="34" y="446">25</tspan><tspan x="34" y="464">26</tspan><tspan x="34" y="482">27</tspan><tspan x="34" y="500">28</tspan><tspan x="34" y="518">29</tspan><tspan x="34" y="536">30</tspan><tspan x="34" y="554">31</tspan><tspan x="34" y="572">32</tspan></text>
+      <text class="container fg7"><tspan xml:space="preserve" x="42" y="14" class="output"><tspan class="bold">test</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="32" class="output">  <tspan class="bold">app_name</tspan>: <tspan class="fg6">test</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="50" class="output">  <tspan class="bold">cache_size</tspan>: <tspan class="fg6">128 MiB</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="68" class="output">  <tspan class="bold">dir_paths</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="86" class="output">    - <tspan class="fg6">/usr/bin</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="104" class="output">    - <tspan class="fg6">/usr/local/bin</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="122" class="output">  <tspan class="bold">funding</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="140" class="output">    <tspan class="bold">address</tspan>: <tspan class="fg6">'0x0000000000000000000000000000000000001234'</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="158" class="output">    <tspan class="bold">api_key</tspan>: <tspan class="fg6">correct horse battery staple</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="176" class="output">    <tspan class="bold">balance</tspan>: <tspan class="fg6">'0x123456'</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="194" class="output">    <tspan class="bold">secret_key</tspan>: <tspan class="fg6">0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="212" class="output">  <tspan class="bold">nested</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="230" class="output">    <tspan class="bold">complex</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="248" class="output">      <tspan class="bold">array</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="266" class="output">        - <tspan class="fg2">1</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="284" class="output">        - <tspan class="fg2">2</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="302" class="output">      <tspan class="bold">map</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="320" class="output">        <tspan class="bold">value</tspan>: <tspan class="fg2">25</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="338" class="output">    <tspan class="bold">exit_on_error</tspan>: <tspan class="fg3">false</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="356" class="output">    <tspan class="bold">method_limits</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="374" class="output">      - <tspan class="bold">method</tspan>: <tspan class="fg6">eth_getLogs</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="392" class="output">        <tspan class="bold">rps</tspan>: <tspan class="fg2">100</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="410" class="output">      - <tspan class="bold">method</tspan>: <tspan class="fg6">eth_blockNumber</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="428" class="output">        <tspan class="bold">rps</tspan>: <tspan class="fg2">3</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="446" class="output">  <tspan class="bold">object_store</tspan>:
+</tspan><tspan xml:space="preserve" x="42" y="464" class="output">    <tspan class="bold">bucket_name</tspan>: <tspan class="fg6">test-bucket</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="482" class="output">    <tspan class="bold">type</tspan>: <tspan class="fg6">gcs</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="500" class="output">  <tspan class="bold">poll_latency</tspan>: <tspan class="fg6">300ms</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="518" class="output">  <tspan class="bold">port</tspan>: <tspan class="fg2">3000</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="536" class="output">  <tspan class="bold">required</tspan>: <tspan class="fg2">123</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="554" class="output">  <tspan class="bold">scaling_factor</tspan>: <tspan class="fg2">4.199999809265137</tspan>
+</tspan><tspan xml:space="preserve" x="42" y="572" class="output">  <tspan class="bold">temp_dir</tspan>: <tspan class="fg6">/var/folders/mw/lhb7m9dj3jbdm3w994t0_c8h0000gn/T/</tspan>
+</tspan></text>
+    </svg>
+</svg>

--- a/crates/smart-config-commands/src/help.rs
+++ b/crates/smart-config-commands/src/help.rs
@@ -170,11 +170,18 @@ impl ParamRef<'_> {
             self.write_tag_variant(tag_variant, writer)?;
         }
 
-        if let Some(default) = self.param.default_value_json() {
+        let default = self.param.default_value_json();
+        if let Some(default) = &default {
             write!(writer, "{INDENT}{FIELD}Default{FIELD:#}: ")?;
-            write_json_value(writer, &default, 2)?;
+            write_json_value(writer, default, 2)?;
             writeln!(writer)?;
-        } else if let Some(example) = self.param.example_value_json() {
+        }
+
+        let example = self
+            .param
+            .example_value_json()
+            .filter(|val| Some(val) != default.as_ref());
+        if let Some(example) = example {
             write!(writer, "{INDENT}{FIELD}Example{FIELD:#}: ")?;
             write_json_value(writer, &example, 2)?;
             writeln!(writer)?;

--- a/crates/smart-config-commands/src/help.rs
+++ b/crates/smart-config-commands/src/help.rs
@@ -174,7 +174,12 @@ impl ParamRef<'_> {
             write!(writer, "{INDENT}{FIELD}Default{FIELD:#}: ")?;
             write_json_value(writer, &default, 2)?;
             writeln!(writer)?;
+        } else if let Some(example) = self.param.example_value_json() {
+            write!(writer, "{INDENT}{FIELD}Example{FIELD:#}: ")?;
+            write_json_value(writer, &example, 2)?;
+            writeln!(writer)?;
         }
+
         if let Some(fallback) = self.param.fallback {
             write!(writer, "{INDENT}{FIELD}Fallbacks{FIELD:#}: ")?;
             let fallback = fallback.to_string();

--- a/crates/smart-config-commands/src/utils.rs
+++ b/crates/smart-config-commands/src/utils.rs
@@ -1,9 +1,12 @@
 //! Functionality shared by multiple CLI commands.
 
-use std::io;
+use std::io::{self, Write as _};
 
+use anstream::stream::{AsLockedWrite, RawStream};
 use anstyle::{AnsiColor, Color, Style};
 use smart_config::value::{StrValue, Value, WithOrigin};
+
+use crate::Printer;
 
 pub(crate) const STRING: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Cyan)));
 const NULL: Style = Style::new().bold();
@@ -13,6 +16,28 @@ const SECRET: Style = Style::new()
     .bg_color(Some(Color::Ansi(AnsiColor::Cyan)))
     .fg_color(None);
 const OBJECT_KEY: Style = Style::new().bold();
+
+impl<W: RawStream + AsLockedWrite> Printer<W> {
+    /// Outputs JSON with syntax highlighting.
+    ///
+    /// # Errors
+    ///
+    /// Proxies I/O errors.
+    pub fn print_json(&mut self, json: &serde_json::Value) -> io::Result<()> {
+        write_json_value(&mut self.writer, json, 0)?;
+        writeln!(&mut self.writer)
+    }
+
+    /// Outputs YAML adhering to the JSON model with syntax highlighting.
+    ///
+    /// # Errors
+    ///
+    /// Proxies I/O errors.
+    pub fn print_yaml(&mut self, json: &serde_json::Value) -> io::Result<()> {
+        write_yaml_value(&mut self.writer, json, 0, false)?;
+        writeln!(&mut self.writer)
+    }
+}
 
 pub(crate) fn write_json_value(
     writer: &mut impl io::Write,
@@ -29,10 +54,14 @@ pub(crate) fn write_json_value(
                 write!(writer, "[]")
             } else {
                 writeln!(writer, "[")?;
-                for item in val {
+                for (i, item) in val.iter().enumerate() {
                     write!(writer, "{:ident$}  ", "")?;
                     write_json_value(writer, item, ident + 2)?;
-                    writeln!(writer, ",")?;
+                    if i + 1 < val.len() {
+                        writeln!(writer, ",")?;
+                    } else {
+                        writeln!(writer)?;
+                    }
                 }
                 write!(writer, "{:ident$}]", "")
             }
@@ -42,12 +71,96 @@ pub(crate) fn write_json_value(
                 write!(writer, "{{}}")
             } else {
                 writeln!(writer, "{{")?;
-                for (key, value) in val {
+                for (i, (key, value)) in val.iter().enumerate() {
                     write!(writer, "{:ident$}  {OBJECT_KEY}{key:?}{OBJECT_KEY:#}: ", "")?;
                     write_json_value(writer, value, ident + 2)?;
-                    writeln!(writer, ",")?;
+                    if i + 1 < val.len() {
+                        writeln!(writer, ",")?;
+                    } else {
+                        writeln!(writer)?;
+                    }
                 }
                 write!(writer, "{:ident$}}}", "")
+            }
+        }
+    }
+}
+
+fn yaml_string(val: &str) -> String {
+    // YAML has arcane rules escaping strings, so we just use the library.
+    let mut yaml = serde_yaml::to_string(val).unwrap();
+    if yaml.ends_with('\n') {
+        yaml.pop();
+    }
+    yaml
+}
+
+fn write_yaml_value(
+    writer: &mut impl io::Write,
+    value: &serde_json::Value,
+    ident: usize,
+    is_array_item: bool,
+) -> io::Result<()> {
+    match value {
+        serde_json::Value::Null => write!(writer, "{NULL}null{NULL:#}"),
+        serde_json::Value::Bool(val) => write!(writer, "{BOOL}{val:?}{BOOL:#}"),
+        serde_json::Value::Number(val) => write!(writer, "{NUMBER}{val}{NUMBER:#}"),
+        serde_json::Value::String(val) => {
+            let yaml_val = yaml_string(val);
+            write!(writer, "{STRING}{yaml_val}{STRING:#}")
+        }
+        serde_json::Value::Array(val) => {
+            if val.is_empty() {
+                if ident > 0 {
+                    write!(writer, " ")?; // We haven't output a space before the array in the parent array / object
+                }
+                write!(writer, "[]")
+            } else {
+                if ident > 0 {
+                    writeln!(writer)?;
+                }
+                for (i, item) in val.iter().enumerate() {
+                    write!(writer, "{:ident$}-", "")?;
+                    if !item.is_array() {
+                        write!(writer, " ")?; // If the item is another array, we'll output a newline instead
+                    }
+
+                    write_yaml_value(writer, item, ident + 2, true)?;
+                    if i + 1 < val.len() {
+                        writeln!(writer)?;
+                    }
+                }
+                Ok(())
+            }
+        }
+        serde_json::Value::Object(val) => {
+            if val.is_empty() {
+                if ident > 0 {
+                    write!(writer, " ")?; // We haven't output a space before the array in the parent array / object
+                }
+                write!(writer, "{{}}")
+            } else {
+                if ident > 0 && !is_array_item {
+                    writeln!(writer)?;
+                }
+                for (i, (key, value)) in val.iter().enumerate() {
+                    let yaml_key = yaml_string(key);
+                    if is_array_item && i == 0 {
+                        // Skip padding for the first item in an array
+                    } else {
+                        write!(writer, "{:ident$}", "")?;
+                    }
+                    write!(writer, "{OBJECT_KEY}{yaml_key}{OBJECT_KEY:#}:")?;
+                    if !value.is_object() && !value.is_array() {
+                        write!(writer, " ")?; // If the child value is an object or array, we'll output a newline
+                    }
+
+                    write_yaml_value(writer, value, ident + 2, false)?;
+                    if i + 1 < val.len() {
+                        writeln!(writer)?;
+                    }
+                }
+                Ok(())
             }
         }
     }
@@ -82,5 +195,58 @@ pub(crate) fn write_value(
             }
             write!(writer, "{:ident$}}}", "")
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anstream::AutoStream;
+
+    use crate::utils::write_yaml_value;
+
+    #[test]
+    fn writing_yaml() {
+        let original_yaml = "\
+test:
+  app_name: test
+  cache_size: 128 MiB
+  dir_paths:
+    - /usr/local/bin
+    - /usr/bin
+  funding:
+    address: '0x0000000000000000000000000000000000001234'
+    api_key: correct horse battery staple
+    balance: '0x123456'
+    secret_key: 0x000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f
+  nested:
+    complex:
+      array:
+        - 1
+        - 2
+      map:
+        value: 25
+    exit_on_error: false
+    method_limits:
+      - method: eth_blockNumber
+        rps: 3
+      - method: eth_getLogs
+        rps: 100
+    more_timeouts: []
+  object_store:
+    bucket_name: test-bucket
+    type: gcs
+  poll_latency: 300ms
+  port: 3000
+  required: 123
+  scaling_factor: 4.199999809265137
+  temp_dir: /var/folders/mw/lhb7m9dj3jbdm3w994t0_c8h0000gn/T/
+  timeout_sec: 60";
+        let json: serde_json::Value = serde_yaml::from_str(original_yaml).unwrap();
+        assert!(json["test"].as_object().unwrap().len() > 10, "{json:?}");
+
+        let mut buffer = vec![];
+        write_yaml_value(&mut AutoStream::never(&mut buffer), &json, 0, false).unwrap();
+        let produced_yaml = String::from_utf8(buffer).unwrap();
+        assert_eq!(produced_yaml, original_yaml);
     }
 }

--- a/crates/smart-config-derive/src/example.rs
+++ b/crates/smart-config-derive/src/example.rs
@@ -19,6 +19,8 @@ impl ConfigField {
             default.instance(name_span)
         } else if self.attrs.nest {
             quote_spanned!(name_span=> #cr::ExampleConfig::example_config())
+        } else if Self::is_option(&self.ty) {
+            quote_spanned!(name_span=> ::core::option::Option::None)
         } else {
             let msg = "example or default value required to derive `ExampleConfig`";
             return Err(syn::Error::new(name_span, msg));

--- a/crates/smart-config-derive/src/example.rs
+++ b/crates/smart-config-derive/src/example.rs
@@ -1,0 +1,66 @@
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{quote, quote_spanned};
+use syn::DeriveInput;
+
+use crate::utils::{ConfigContainer, ConfigContainerFields, ConfigField};
+
+impl ConfigField {
+    fn example_initializer(
+        &self,
+        cr: &proc_macro2::TokenStream,
+    ) -> syn::Result<proc_macro2::TokenStream> {
+        let name = &self.name;
+        let name_span = self.name_span();
+        let val = if self.attrs.nest {
+            quote_spanned!(name_span=> #cr::ExampleConfig::example_config())
+        } else if let Some(default) = &self.attrs.default {
+            default.instance(name_span)
+        } else if let Some(example) = &self.attrs.example {
+            quote!(#example)
+        } else {
+            let msg = "example or default value required to derive `ExampleConfig`";
+            return Err(syn::Error::new(name_span, msg));
+        };
+        Ok(quote_spanned!(name_span=> #name: #val))
+    }
+}
+
+impl ConfigContainer {
+    fn derive_example(&self) -> syn::Result<proc_macro2::TokenStream> {
+        let name = &self.name;
+        let cr = self.cr(Span::call_site());
+
+        let example_impl = match &self.fields {
+            ConfigContainerFields::Struct(fields) => {
+                let fields: syn::Result<Vec<_>> = fields
+                    .iter()
+                    .map(|field| field.example_initializer(&cr))
+                    .collect();
+                let fields = fields?;
+                quote!(Self { #(#fields,)* })
+            }
+            ConfigContainerFields::Enum { .. } => todo!(),
+        };
+
+        Ok(quote! {
+            impl #cr::ExampleConfig for #name {
+                fn example_config() -> Self {
+                    #example_impl
+                }
+            }
+        })
+    }
+}
+
+pub(crate) fn impl_example_config(input: TokenStream) -> TokenStream {
+    let input: DeriveInput = syn::parse(input).unwrap();
+    let trait_impl = match ConfigContainer::new(&input) {
+        Ok(trait_impl) => trait_impl,
+        Err(err) => return err.into_compile_error().into(),
+    };
+    match trait_impl.derive_example() {
+        Ok(derived) => derived.into(),
+        Err(err) => err.into_compile_error().into(),
+    }
+}

--- a/crates/smart-config-derive/src/lib.rs
+++ b/crates/smart-config-derive/src/lib.rs
@@ -14,11 +14,17 @@ use proc_macro::TokenStream;
 
 mod de;
 mod describe;
+mod example;
 mod utils;
 
 #[proc_macro_derive(DescribeConfig, attributes(config))]
 pub fn describe_config(input: TokenStream) -> TokenStream {
     describe::impl_describe_config(input)
+}
+
+#[proc_macro_derive(ExampleConfig, attributes(config))]
+pub fn example_config(input: TokenStream) -> TokenStream {
+    example::impl_example_config(input)
 }
 
 #[proc_macro_derive(DeserializeConfig, attributes(config))]

--- a/crates/smart-config-derive/src/utils.rs
+++ b/crates/smart-config-derive/src/utils.rs
@@ -159,6 +159,7 @@ pub(crate) struct ConfigFieldAttrs {
 }
 
 impl ConfigFieldAttrs {
+    #[allow(clippy::too_many_lines)]
     fn new(attrs: &[Attribute], is_option: bool) -> syn::Result<Self> {
         let config_attrs = attrs.iter().filter(|attr| attr.path().is_ident("config"));
 

--- a/crates/smart-config-derive/src/utils.rs
+++ b/crates/smart-config-derive/src/utils.rs
@@ -252,15 +252,6 @@ impl ConfigFieldAttrs {
             return Err(syn::Error::new(secret_span, msg));
         }
 
-        if let (Some(example), Some(_)) = (&example, &default) {
-            let msg = "Specifying `example` is redundant for params having default values";
-            return Err(syn::Error::new(example.span(), msg));
-        }
-        if let (Some(example), true) = (&example, nest) {
-            let msg = "Specifying `example` only works for params, not nested / flattened configs";
-            return Err(syn::Error::new(example.span(), msg));
-        }
-
         Ok(Self {
             rename,
             aliases,

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -337,7 +337,7 @@ pub use smart_config_derive::DeserializeConfig;
 ///
 /// ```
 /// # use std::collections::HashSet;
-/// # use smart_config::{DescribeConfig, ExampleConfig, visit::serialize_to_json};
+/// # use smart_config::{DescribeConfig, ExampleConfig, SerializerOptions};
 /// #[derive(DescribeConfig, ExampleConfig)]
 /// struct TestConfig {
 ///     /// Required param that still has an example value.
@@ -359,7 +359,7 @@ pub use smart_config_derive::DeserializeConfig;
 /// }
 ///
 /// let example: TestConfig = TestConfig::example_config();
-/// let json = serialize_to_json(&example);
+/// let json = SerializerOptions::default().serialize(&example);
 /// assert_eq!(
 ///     serde_json::Value::from(json),
 ///     serde_json::json!({
@@ -381,7 +381,7 @@ pub use self::{
     schema::{ConfigMut, ConfigRef, ConfigSchema},
     source::{
         ConfigContents, ConfigParser, ConfigRepository, ConfigSource, ConfigSources, Environment,
-        Json, Prefixed, SourceInfo, Yaml,
+        Json, Prefixed, SerializerOptions, SourceInfo, Yaml,
     },
     types::ByteSize,
 };

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -360,12 +360,6 @@ pub trait ExampleConfig {
     fn example_config() -> Self;
 }
 
-impl<T: Default + DescribeConfig> ExampleConfig for T {
-    fn example_config() -> Self {
-        Self::default()
-    }
-}
-
 impl<T: ExampleConfig> ExampleConfig for Option<T> {
     fn example_config() -> Self {
         Some(T::example_config())

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -316,6 +316,11 @@ pub use smart_config_derive::DescribeConfig;
 /// This macro is intended to be used together with [`DescribeConfig`](macro@DescribeConfig). It reuses
 /// the same attributes, so see `DescribeConfig` docs for details and examples of usage.
 pub use smart_config_derive::DeserializeConfig;
+/// Derives the [`ExampleConfig`](trait@ExampleConfig) trait for a type.
+///
+/// This macro is intended to be used together with [`DescribeConfig`](macro@DescribeConfig). It reuses
+/// the same attributes, so see `DescribeConfig` docs for details and examples of usage.
+pub use smart_config_derive::ExampleConfig;
 
 pub use self::{
     de::DeserializeConfig,
@@ -348,6 +353,23 @@ pub mod visit;
 pub trait DescribeConfig: 'static + VisitConfig {
     /// Provides the config description.
     const DESCRIPTION: ConfigMetadata;
+}
+
+#[allow(missing_docs)] // FIXME
+pub trait ExampleConfig {
+    fn example_config() -> Self;
+}
+
+impl<T: Default + DescribeConfig> ExampleConfig for T {
+    fn example_config() -> Self {
+        Self::default()
+    }
+}
+
+impl<T: ExampleConfig> ExampleConfig for Option<T> {
+    fn example_config() -> Self {
+        Some(T::example_config())
+    }
 }
 
 #[cfg(doctest)]

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -223,6 +223,13 @@
 ///
 /// Allows to specify the default typed value for the param. The provided expression doesn't need to be constant.
 ///
+/// ## `example`
+///
+/// **Type:** expression with field type
+///
+/// Allows to specify the example value for the param. The example value can be specified together with the `default` / `default_t`
+/// attribute. In this case, the example value can be more "complex" than the default, to better illustrate how the configuration works.
+///
 /// ## `fallback`
 ///
 /// **Type:** constant expression evaluating to `&'static dyn `[`FallbackSource`](fallback::FallbackSource)
@@ -318,8 +325,54 @@ pub use smart_config_derive::DescribeConfig;
 pub use smart_config_derive::DeserializeConfig;
 /// Derives the [`ExampleConfig`](trait@ExampleConfig) trait for a type.
 ///
-/// This macro is intended to be used together with [`DescribeConfig`](macro@DescribeConfig). It reuses
-/// the same attributes, so see `DescribeConfig` docs for details and examples of usage.
+/// This macro is intended to be used together with [`DescribeConfig`](macro@DescribeConfig); it reuses
+/// the same attributes. Specifically, for each config field, the default value is assigned from the following sources
+/// in the decreasing priority order:
+///
+/// 1. `example`
+/// 2. `default` / `default_t`, including implied ones for `Option`al fields
+/// 3. From [`ExampleConfig`](trait@ExampleConfig) implementation (only for nested / flattened configs)
+///
+/// # Examples
+///
+/// ```
+/// # use std::collections::HashSet;
+/// # use smart_config::{DescribeConfig, ExampleConfig, visit::serialize_to_json};
+/// #[derive(DescribeConfig, ExampleConfig)]
+/// struct TestConfig {
+///     /// Required param that still has an example value.
+///     #[config(example = 42)]
+///     required: u32,
+///     optional: Option<String>,
+///     #[config(default_t = true)]
+///     with_default: bool,
+///     #[config(default, example = vec![5, 8])]
+///     values: Vec<u32>,
+///     #[config(nest)]
+///     nested: NestedConfig,
+/// }
+///
+/// #[derive(DescribeConfig, ExampleConfig)]
+/// struct NestedConfig {
+///     #[config(default, example = ["eth_call".into()].into())]
+///     methods: HashSet<String>,
+/// }
+///
+/// let example: TestConfig = TestConfig::example_config();
+/// let json = serialize_to_json(&example);
+/// assert_eq!(
+///     serde_json::Value::from(json),
+///     serde_json::json!({
+///         "required": 42,
+///         "optional": null,
+///         "with_default": true,
+///         "values": [5, 8],
+///         "nested": {
+///             "methods": ["eth_call"],
+///         },
+///     })
+/// );
+/// ```
 pub use smart_config_derive::ExampleConfig;
 
 pub use self::{
@@ -355,8 +408,11 @@ pub trait DescribeConfig: 'static + VisitConfig {
     const DESCRIPTION: ConfigMetadata;
 }
 
-#[allow(missing_docs)] // FIXME
+/// Provides an example for this configuration. The produced config can be used in tests etc.
+///
+/// For struct configs, this can be derived via [the corresponding proc macro](macro@ExampleConfig).
 pub trait ExampleConfig {
+    /// Constructs an example configuration.
     fn example_config() -> Self;
 }
 

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -80,6 +80,8 @@ pub struct ParamMetadata {
     pub deserializer: &'static dyn ErasedDeserializer,
     #[doc(hidden)] // implementation detail
     pub default_value: Option<fn() -> Box<dyn any::Any>>,
+    #[doc(hidden)] // implementation detail
+    pub example_value: Option<fn() -> Box<dyn any::Any>>,
     #[doc(hidden)]
     pub fallback: Option<&'static dyn FallbackSource>,
 }
@@ -94,6 +96,12 @@ impl ParamMetadata {
     pub fn default_value_json(&self) -> Option<serde_json::Value> {
         self.default_value()
             .map(|val| self.deserializer.serialize_param(val.as_ref()))
+    }
+
+    /// Returns the example value for the param serialized into JSON.
+    pub fn example_value_json(&self) -> Option<serde_json::Value> {
+        let example = self.example_value?();
+        Some(self.deserializer.serialize_param(example.as_ref()))
     }
 
     /// Returns the type description for this param as provided by its deserializer.

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -14,7 +14,9 @@ use crate::{
     schema::{ConfigRef, ConfigSchema},
     utils::{merge_json, JsonObject},
     value::{Map, Pointer, Value, ValueOrigin, WithOrigin},
-    visit, DeserializeConfig, DeserializeConfigError, ParseError, ParseErrors,
+    visit,
+    visit::Serializer,
+    DescribeConfig, DeserializeConfig, DeserializeConfigError, ParseError, ParseErrors,
 };
 
 #[macro_use]
@@ -120,6 +122,29 @@ pub struct SourceInfo {
     pub origin: Arc<ValueOrigin>,
     /// Number of params in the source after it has undergone preprocessing (i.e., merging aliases etc.).
     pub param_count: usize,
+}
+
+/// Configuration serialization options.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct SerializerOptions {
+    pub(crate) diff_with_default: bool,
+}
+
+impl SerializerOptions {
+    /// Will serialize only params with values differing from the default value.
+    pub fn diff_with_default() -> Self {
+        Self {
+            diff_with_default: true,
+        }
+    }
+
+    /// Serializes a config to JSON, recursively visiting its nested configs.
+    pub fn serialize<C: DescribeConfig>(self, config: &C) -> JsonObject {
+        let mut visitor = Serializer::new(&C::DESCRIPTION, self);
+        config.visit_config(&mut visitor);
+        visitor.into_inner()
+    }
 }
 
 /// Configuration repository containing zero or more [configuration sources](ConfigSource).
@@ -283,7 +308,7 @@ impl<'a> ConfigRepository<'a> {
     ///
     /// If parsing any of the config fails, returns parsing errors early (i.e., errors are **not** exhaustive).
     #[doc(hidden)] // not stable yet
-    pub fn canonicalize(&self, diff_with_default: bool) -> Result<JsonObject, ParseErrors> {
+    pub fn canonicalize(&self, options: &SerializerOptions) -> Result<JsonObject, ParseErrors> {
         let mut json = serde_json::Map::new();
         for config_parser in self.iter() {
             if !config_parser.config().is_top_level() {
@@ -294,7 +319,7 @@ impl<'a> ConfigRepository<'a> {
             let parsed = config_parser.parse()?;
             let metadata = config_parser.config().metadata();
             let visitor_fn = metadata.visitor;
-            let mut visitor = visit::Serializer::new(metadata, diff_with_default);
+            let mut visitor = visit::Serializer::new(metadata, options.clone());
             visitor_fn(parsed.as_ref(), &mut visitor);
             merge_json(
                 &mut json,

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -283,7 +283,7 @@ impl<'a> ConfigRepository<'a> {
     ///
     /// If parsing any of the config fails, returns parsing errors early (i.e., errors are **not** exhaustive).
     #[doc(hidden)] // not stable yet
-    pub fn canonicalize(&self) -> Result<JsonObject, ParseErrors> {
+    pub fn canonicalize(&self, diff_with_default: bool) -> Result<JsonObject, ParseErrors> {
         let mut json = serde_json::Map::new();
         for config_parser in self.iter() {
             if !config_parser.config().is_top_level() {
@@ -294,7 +294,7 @@ impl<'a> ConfigRepository<'a> {
             let parsed = config_parser.parse()?;
             let metadata = config_parser.config().metadata();
             let visitor_fn = metadata.visitor;
-            let mut visitor = visit::Serializer::new(metadata);
+            let mut visitor = visit::Serializer::new(metadata, diff_with_default);
             visitor_fn(parsed.as_ref(), &mut visitor);
             merge_json(
                 &mut json,

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -19,7 +19,7 @@ use crate::{
         EnumConfig, KvTestConfig, NestedConfig, SecretConfig, SimpleEnum, ValueCoercingConfig,
     },
     value::StrValue,
-    visit::Serializer,
+    visit::serialize_to_json,
     ByteSize, DescribeConfig,
 };
 
@@ -649,7 +649,7 @@ fn parsing_complex_param() {
     assert_eq!(config.param.repeated, HashSet::from([SimpleEnum::First]));
     assert_eq!(config.set, HashSet::from([1, 2, 3]));
 
-    let json = Serializer::json(&config);
+    let json = serialize_to_json(&config);
     assert_eq!(
         json["param"],
         serde_json::json!({

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -649,7 +649,8 @@ fn parsing_complex_param() {
     assert_eq!(config.param.repeated, HashSet::from([SimpleEnum::First]));
     assert_eq!(config.set, HashSet::from([1, 2, 3]));
 
-    let json = serialize_to_json(&config);
+    let json = serialize_to_json(&config, false);
+    assert!(json.contains_key("repeated"), "{json:?}");
     assert_eq!(
         json["param"],
         serde_json::json!({
@@ -662,8 +663,13 @@ fn parsing_complex_param() {
         })
     );
 
-    let config_copy: ValueCoercingConfig = testing::test(Json::new("test.json", json)).unwrap();
+    let config_copy: ValueCoercingConfig =
+        testing::test(Json::new("test.json", json.clone())).unwrap();
     assert_eq!(config_copy, config);
+
+    let json_diff = serialize_to_json(&config, true);
+    assert!(!json_diff.contains_key("repeated"), "{json_diff:?}");
+    assert_eq!(json_diff["param"], json["param"]);
 
     let env = Environment::from_iter(
         "",

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -13,13 +13,13 @@ use crate::{
     testing,
     testing::MockEnvGuard,
     testonly::{
-        extract_env_var_name, extract_json_name, serialize_to_json, test_config_roundtrip,
-        test_deserialize, AliasedConfig, ComposedConfig, CompoundConfig, ConfigWithComplexTypes,
-        ConfigWithFallbacks, ConfigWithNestedValidations, ConfigWithNesting, ConfigWithValidations,
-        DefaultingConfig, EnumConfig, KvTestConfig, NestedConfig, SecretConfig, SimpleEnum,
-        ValueCoercingConfig,
+        extract_env_var_name, extract_json_name, test_config_roundtrip, test_deserialize,
+        AliasedConfig, ComposedConfig, CompoundConfig, ConfigWithComplexTypes, ConfigWithFallbacks,
+        ConfigWithNestedValidations, ConfigWithNesting, ConfigWithValidations, DefaultingConfig,
+        EnumConfig, KvTestConfig, NestedConfig, SecretConfig, SimpleEnum, ValueCoercingConfig,
     },
     value::StrValue,
+    visit::serialize_to_json,
     ByteSize, DescribeConfig,
 };
 

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -19,8 +19,7 @@ use crate::{
         EnumConfig, KvTestConfig, NestedConfig, SecretConfig, SimpleEnum, ValueCoercingConfig,
     },
     value::StrValue,
-    visit::serialize_to_json,
-    ByteSize, DescribeConfig,
+    ByteSize, DescribeConfig, SerializerOptions,
 };
 
 #[test]
@@ -649,7 +648,7 @@ fn parsing_complex_param() {
     assert_eq!(config.param.repeated, HashSet::from([SimpleEnum::First]));
     assert_eq!(config.set, HashSet::from([1, 2, 3]));
 
-    let json = serialize_to_json(&config, false);
+    let json = SerializerOptions::default().serialize(&config);
     assert!(json.contains_key("repeated"), "{json:?}");
     assert_eq!(
         json["param"],
@@ -667,7 +666,7 @@ fn parsing_complex_param() {
         testing::test(Json::new("test.json", json.clone())).unwrap();
     assert_eq!(config_copy, config);
 
-    let json_diff = serialize_to_json(&config, true);
+    let json_diff = SerializerOptions::diff_with_default().serialize(&config);
     assert!(!json_diff.contains_key("repeated"), "{json_diff:?}");
     assert_eq!(json_diff["param"], json["param"]);
 

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -19,7 +19,7 @@ use crate::{
         EnumConfig, KvTestConfig, NestedConfig, SecretConfig, SimpleEnum, ValueCoercingConfig,
     },
     value::StrValue,
-    visit::serialize_to_json,
+    visit::Serializer,
     ByteSize, DescribeConfig,
 };
 
@@ -649,7 +649,7 @@ fn parsing_complex_param() {
     assert_eq!(config.param.repeated, HashSet::from([SimpleEnum::First]));
     assert_eq!(config.set, HashSet::from([1, 2, 3]));
 
-    let json = serialize_to_json(&config);
+    let json = Serializer::json(&config);
     assert_eq!(
         json["param"],
         serde_json::json!({

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -24,7 +24,7 @@ use crate::{
     testing,
     validation::NotEmpty,
     value::{FileFormat, Value, ValueOrigin, WithOrigin},
-    visit::serialize_to_json,
+    visit::Serializer,
     ByteSize, ConfigSource, DescribeConfig, DeserializeConfig, Environment, ErrorWithOrigin,
     ExampleConfig, Json, ParseErrors,
 };
@@ -431,7 +431,7 @@ pub(crate) fn test_config_roundtrip<C>(config: &C) -> serde_json::Map<String, se
 where
     C: DeserializeConfig + PartialEq + fmt::Debug,
 {
-    let json = serialize_to_json(config);
+    let json = Serializer::json(config);
     let config_copy: C = testing::test(Json::new("test.json", json.clone())).unwrap();
     assert_eq!(config_copy, *config);
     json
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn example_for_simple_config() {
-        let example_json = serialize_to_json(&NestedConfig::example_config());
+        let example_json = Serializer::json(&NestedConfig::example_config());
         assert_eq!(
             serde_json::Value::from(example_json),
             serde_json::json!({
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn example_for_compound_config() {
-        let example_json = serialize_to_json(&CompoundConfig::example_config());
+        let example_json = Serializer::json(&CompoundConfig::example_config());
         let expected_nested_json = serde_json::json!({
             "map": { "var": 42 },
             "other_int": 42,
@@ -494,13 +494,13 @@ mod tests {
     fn serializing_enum_config() {
         let config = RenamedEnumConfig::V0;
         assert_eq!(
-            serde_json::Value::from(serialize_to_json(&config)),
+            serde_json::Value::from(Serializer::json(&config)),
             serde_json::json!({ "version": "v0" })
         );
 
         let config = RenamedEnumConfig::V1 { int: 23 };
         assert_eq!(
-            serde_json::Value::from(serialize_to_json(&config)),
+            serde_json::Value::from(Serializer::json(&config)),
             serde_json::json!({ "version": "v1", "int": 23 })
         );
 
@@ -508,7 +508,7 @@ mod tests {
             str: "??".to_owned(),
         };
         assert_eq!(
-            serde_json::Value::from(serialize_to_json(&config)),
+            serde_json::Value::from(Serializer::json(&config)),
             serde_json::json!({ "version": "v2", "str": "??" })
         );
     }

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -77,7 +77,7 @@ pub(crate) struct NestedConfig {
     pub simple_enum: SimpleEnum,
     #[config(default_t = 42)]
     pub other_int: u32,
-    #[config(default)]
+    #[config(default, example = HashMap::from([("var".to_owned(), 42)]))]
     pub map: HashMap<String, u32>,
 }
 
@@ -144,6 +144,10 @@ pub(crate) struct CompoundConfig {
     #[config(rename = "default", nest, default = NestedConfig::default_nested)]
     pub nested_default: NestedConfig,
     #[config(flatten)]
+    #[config(example = NestedConfig {
+        simple_enum: SimpleEnum::Second,
+        ..NestedConfig::example_config()
+    })]
     pub flat: NestedConfig,
 }
 
@@ -454,7 +458,7 @@ mod tests {
         assert_eq!(
             serde_json::Value::from(example_json),
             serde_json::json!({
-                "map": {},
+                "map": { "var": 42 },
                 "other_int": 42,
                 "renamed": "first",
             })
@@ -465,19 +469,23 @@ mod tests {
     fn example_for_compound_config() {
         let example_json = serialize_to_json(&CompoundConfig::example_config());
         let expected_nested_json = serde_json::json!({
-            "map": {},
+            "map": { "var": 42 },
             "other_int": 42,
             "renamed": "first",
         });
         assert_eq!(
             serde_json::Value::from(example_json),
             serde_json::json!({
-                "default": &expected_nested_json,
+                "default": {
+                    "map": {},
+                    "other_int": 23,
+                    "renamed": "first",
+                },
                 "nested": &expected_nested_json,
                 "nested_opt": &expected_nested_json,
-                "map": {},
+                "map": { "var": 42 },
                 "other_int": 42,
-                "renamed": "first",
+                "renamed": "second",
             })
         );
     }

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -24,7 +24,7 @@ use crate::{
     testing,
     validation::NotEmpty,
     value::{FileFormat, Value, ValueOrigin, WithOrigin},
-    visit::Serializer,
+    visit::serialize_to_json,
     ByteSize, ConfigSource, DescribeConfig, DeserializeConfig, Environment, ErrorWithOrigin,
     ExampleConfig, Json, ParseErrors,
 };
@@ -431,7 +431,7 @@ pub(crate) fn test_config_roundtrip<C>(config: &C) -> serde_json::Map<String, se
 where
     C: DeserializeConfig + PartialEq + fmt::Debug,
 {
-    let json = Serializer::json(config);
+    let json = serialize_to_json(config);
     let config_copy: C = testing::test(Json::new("test.json", json.clone())).unwrap();
     assert_eq!(config_copy, *config);
     json
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn example_for_simple_config() {
-        let example_json = Serializer::json(&NestedConfig::example_config());
+        let example_json = serialize_to_json(&NestedConfig::example_config());
         assert_eq!(
             serde_json::Value::from(example_json),
             serde_json::json!({
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn example_for_compound_config() {
-        let example_json = Serializer::json(&CompoundConfig::example_config());
+        let example_json = serialize_to_json(&CompoundConfig::example_config());
         let expected_nested_json = serde_json::json!({
             "map": { "var": 42 },
             "other_int": 42,
@@ -494,13 +494,13 @@ mod tests {
     fn serializing_enum_config() {
         let config = RenamedEnumConfig::V0;
         assert_eq!(
-            serde_json::Value::from(Serializer::json(&config)),
+            serde_json::Value::from(serialize_to_json(&config)),
             serde_json::json!({ "version": "v0" })
         );
 
         let config = RenamedEnumConfig::V1 { int: 23 };
         assert_eq!(
-            serde_json::Value::from(Serializer::json(&config)),
+            serde_json::Value::from(serialize_to_json(&config)),
             serde_json::json!({ "version": "v1", "int": 23 })
         );
 
@@ -508,7 +508,7 @@ mod tests {
             str: "??".to_owned(),
         };
         assert_eq!(
-            serde_json::Value::from(Serializer::json(&config)),
+            serde_json::Value::from(serialize_to_json(&config)),
             serde_json::json!({ "version": "v2", "str": "??" })
         );
     }

--- a/crates/smart-config/src/value.rs
+++ b/crates/smart-config/src/value.rs
@@ -2,8 +2,7 @@
 
 use std::{collections::HashMap, fmt, iter, mem, sync::Arc};
 
-use secrecy::ExposeSecret;
-pub use secrecy::SecretString;
+pub use secrecy::{ExposeSecret, SecretString};
 
 use crate::metadata::BasicTypes;
 

--- a/crates/smart-config/src/visit.rs
+++ b/crates/smart-config/src/visit.rs
@@ -2,7 +2,7 @@
 
 use std::{any, any::Any, mem};
 
-use crate::{metadata::ConfigMetadata, utils::JsonObject};
+use crate::{metadata::ConfigMetadata, utils::JsonObject, DescribeConfig};
 
 /// Visitor of configuration parameters in a particular configuration.
 #[doc(hidden)] // API is not stable yet
@@ -57,14 +57,6 @@ impl Serializer {
     pub(crate) fn into_inner(self) -> JsonObject {
         self.json
     }
-
-    /// Serializes a config to JSON, recursively visiting its nested configs.
-    #[cfg(test)]
-    pub(crate) fn json<C: crate::DescribeConfig>(config: &C) -> JsonObject {
-        let mut visitor = Self::new(&C::DESCRIPTION);
-        config.visit_config(&mut visitor);
-        visitor.json
-    }
 }
 
 impl ConfigVisitor for Serializer {
@@ -99,6 +91,13 @@ impl ConfigVisitor for Serializer {
 
         self.metadata = prev_metadata;
     }
+}
+
+/// Serializes a config to JSON, recursively visiting its nested configs.
+pub fn serialize_to_json<C: DescribeConfig>(config: &C) -> JsonObject {
+    let mut visitor = Serializer::new(&C::DESCRIPTION);
+    config.visit_config(&mut visitor);
+    visitor.json
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# What ❔

- Allows to specify example values for config params.
- Introduces the `ExampleConfig` trait producing an example config.

## Why ❔

- Example param values are useful for documenting purposes.
- Useful to idiomatically define configs for unit testing etc.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.