### PR TITLE
fix: Serialization fixes

### DIFF
--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -211,8 +211,8 @@ impl<'a> DeserializeContext<'a> {
 
     #[cold]
     fn push_generic_error(&mut self, err: ErrorWithOrigin, validation: Option<String>) {
-        let inner = match err.inner {
-            LowLevelError::Json(err) => err,
+        let (inner, category) = match err.inner {
+            LowLevelError::Json { err, category } => (err, category),
             LowLevelError::InvalidArray
             | LowLevelError::InvalidObject
             | LowLevelError::Validation => return,
@@ -227,6 +227,7 @@ impl<'a> DeserializeContext<'a> {
 
         self.errors.push(ParseError {
             inner,
+            category,
             path: self.path.clone(),
             origin,
             config: self.current_config,

--- a/crates/smart-config/src/lib.rs
+++ b/crates/smart-config/src/lib.rs
@@ -377,7 +377,7 @@ pub use smart_config_derive::ExampleConfig;
 
 pub use self::{
     de::DeserializeConfig,
-    error::{DeserializeConfigError, ErrorWithOrigin, ParseError, ParseErrors},
+    error::{DeserializeConfigError, ErrorWithOrigin, ParseError, ParseErrorCategory, ParseErrors},
     schema::{ConfigMut, ConfigRef, ConfigSchema},
     source::{
         ConfigContents, ConfigParser, ConfigRepository, ConfigSource, ConfigSources, Environment,

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -9,6 +9,7 @@ use std::{
 pub use self::{env::Environment, json::Json, yaml::Yaml};
 use crate::{
     de::{DeserializeContext, DeserializerOptions},
+    error::ParseErrorCategory,
     fallback::Fallbacks,
     metadata::BasicTypes,
     schema::{ConfigRef, ConfigSchema},
@@ -314,7 +315,9 @@ impl<'a> ConfigRepository<'a> {
     ///
     /// # Errors
     ///
-    /// If parsing any of the config fails, returns parsing errors early (i.e., errors are **not** exhaustive).
+    /// If parsing any of the configs in the schema fails, returns parsing errors early (i.e., errors are **not** exhaustive).
+    /// Importantly, missing config / parameter errors are swallowed provided this is the only kind of errors for the config,
+    /// and the corresponding config serialization is skipped.
     #[doc(hidden)] // not stable yet
     pub fn canonicalize(&self, options: &SerializerOptions) -> Result<JsonObject, ParseErrors> {
         let mut json = serde_json::Map::new();
@@ -324,7 +327,23 @@ impl<'a> ConfigRepository<'a> {
                 continue;
             }
 
-            let parsed = config_parser.parse()?;
+            let parsed = match config_parser.parse() {
+                Ok(config) => config,
+                Err(err) => {
+                    if err
+                        .iter()
+                        .all(|err| matches!(err.category, ParseErrorCategory::MissingField))
+                    {
+                        tracing::debug!(
+                            config = ?config_parser.config().metadata().ty,
+                            prefix = config_parser.config().prefix(),
+                            "Skipped config because of missing fields"
+                        );
+                        continue;
+                    }
+                    return Err(err);
+                }
+            };
             let metadata = config_parser.config().metadata();
             let visitor_fn = metadata.visitor;
             let mut visitor = visit::Serializer::new(metadata, options.clone());

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -126,9 +126,9 @@ pub struct SourceInfo {
 
 /// Configuration serialization options.
 #[derive(Debug, Clone, Default)]
-#[non_exhaustive]
 pub struct SerializerOptions {
     pub(crate) diff_with_default: bool,
+    pub(crate) secret_placeholder: Option<String>,
 }
 
 impl SerializerOptions {
@@ -136,7 +136,15 @@ impl SerializerOptions {
     pub fn diff_with_default() -> Self {
         Self {
             diff_with_default: true,
+            secret_placeholder: None,
         }
+    }
+
+    /// Sets the placeholder string value for secret params. By default, secrets will be output as-is.
+    #[must_use]
+    pub fn with_secret_placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.secret_placeholder = Some(placeholder.into());
+        self
     }
 
     /// Serializes a config to JSON, recursively visiting its nested configs.

--- a/crates/smart-config/src/utils.rs
+++ b/crates/smart-config/src/utils.rs
@@ -194,19 +194,21 @@ pub(crate) fn merge_json(
     path: &str,
     value: JsonObject,
 ) {
-    for segment in path.split('.') {
-        if !target.contains_key(segment) {
-            target.insert(segment.to_owned(), serde_json::Map::new().into());
-        }
+    if !path.is_empty() {
+        for segment in path.split('.') {
+            if !target.contains_key(segment) {
+                target.insert(segment.to_owned(), serde_json::Map::new().into());
+            }
 
-        // `unwrap()` is safe due to the check above.
-        let child = target.get_mut(segment).unwrap();
-        target = child.as_object_mut().unwrap_or_else(|| {
-            panic!(
-                "Internal error: Attempted to merge {config_name} at '{path}', which is not an object",
-                config_name = metadata.ty.name_in_code()
-            )
-        });
+            // `unwrap()` is safe due to the check above.
+            let child = target.get_mut(segment).unwrap();
+            target = child.as_object_mut().unwrap_or_else(|| {
+                panic!(
+                    "Internal error: Attempted to merge {config_name} at '{path}', which is not an object",
+                    config_name = metadata.ty.name_in_code()
+                )
+            });
+        }
     }
     deep_merge(target, value);
 }


### PR DESCRIPTION
# What ❔

Fixes config serialization in some corner cases, in particular when some configs are mounted at the root, or if some configs cannot be parsed.

## Why ❔

The fixed bugs affect Era integration.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.