### PR TITLE
feat: Support serde-style enums

### DIFF
--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -22,6 +22,11 @@ use crate::{
 pub struct DeserializerOptions {
     /// Enables coercion of variant names between cases, e.g. from `SHOUTING_CASE` to `shouting_case`.
     pub coerce_variant_names: bool,
+    /// Enables coercion of serde-like enums to canonical internally tagged representation.
+    ///
+    /// A serde-style enum is encoded as an object with a single field named after one of variants
+    /// (incl. aliases) converted to `snake_case`. Coercing is performed
+    pub coerce_serde_enums: bool,
 }
 
 impl WithOrigin {

--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -25,7 +25,48 @@ pub struct DeserializerOptions {
     /// Enables coercion of serde-like enums to canonical internally tagged representation.
     ///
     /// A serde-style enum is encoded as an object with a single field named after one of variants
-    /// (incl. aliases) converted to `snake_case`. Coercing is performed
+    /// (incl. aliases) converted to `snake_case`. Coercing is not performed if the tag param is present,
+    /// if there are multiple variant-named fields, or if the variant field value is not an object.
+    /// As a result of coercing, a tag param is added with the appropriate value, and fields in the variant field
+    /// are copied one level upper; they have lower priority than existing fields and never overwrite them.
+    ///
+    /// # Examples
+    ///
+    /// For example, consider an enum config
+    ///
+    /// ```
+    /// use smart_config::{DescribeConfig, DeserializeConfig};
+    /// #[derive(Debug, DescribeConfig, DeserializeConfig)]
+    /// #[config(tag = "type")]
+    /// pub enum TestConfig {
+    ///     String { str: String },
+    ///     IntValue { int: u64 },
+    /// }
+    /// ```
+    ///
+    /// ...mounted at `test`. Then, example serde-style serialization are:
+    ///
+    /// ```yaml
+    /// test:
+    ///   string:
+    ///     str: 'what?'
+    /// ---
+    /// test:
+    ///   int_value:
+    ///     int: 42
+    /// ```
+    ///
+    /// After coercion, these will be transformed to
+    ///
+    /// ```yaml
+    /// test:
+    ///   type: String
+    ///   str: 'what?'
+    /// ---
+    /// test:
+    ///   type: IntValue
+    ///   int: 42
+    /// ```
     pub coerce_serde_enums: bool,
 }
 

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -677,7 +677,7 @@ impl WithOrigin {
             if let Some(new_values) = Self::convert_serde_enum(canonical_map, alias_maps, tag) {
                 let canonical_map = self.ensure_object(prefix, |_| {
                     Arc::new(ValueOrigin::Synthetic {
-                        source: Arc::default(), // FIXME: ???
+                        source: Arc::default(),
                         transform: "enum coercion".to_string(),
                     })
                 });
@@ -709,12 +709,14 @@ impl WithOrigin {
             for (candidate_field_name, variant) in all_variant_names.clone() {
                 if map.contains_key(&candidate_field_name) {
                     if let Some((_, prev_field, _)) = &variant_match {
-                        tracing::info!(
-                            prev_field,
-                            field = candidate_field_name,
-                            "multiple serde-like variant fields present"
-                        );
-                        return None;
+                        if *prev_field != candidate_field_name {
+                            tracing::info!(
+                                prev_field,
+                                field = candidate_field_name,
+                                "multiple serde-like variant fields present"
+                            );
+                            return None;
+                        }
                     }
                     variant_match = Some((map, candidate_field_name, variant));
                 }

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -1541,6 +1541,16 @@ fn coercing_serde_enum() {
 }
 
 #[test]
+fn coercing_serde_enum_with_aliased_field() {
+    let json = config!("fields.str": "?", "fields.flag": false);
+    let config: EnumConfig = testing::test(json).unwrap();
+    assert_matches!(
+        config,
+        EnumConfig::WithFields { string: Some(s), flag: false, .. } if s == "?"
+    );
+}
+
+#[test]
 fn origins_for_coerced_serde_enum() {
     let schema = ConfigSchema::new(&EnumConfig::DESCRIPTION, "");
     let json = config!("fields.string": "!", "fields.flag": false, "fields.set": [123]);

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -1640,3 +1640,45 @@ fn coercing_nested_enum_config() {
         }))
     );
 }
+
+#[test]
+fn coercing_aliased_enum_config() {
+    #[derive(Debug, DescribeConfig, DeserializeConfig)]
+    #[config(crate = crate)]
+    struct ConfigWithNestedEnum {
+        #[config(nest, alias = "value")]
+        val: EnumConfig,
+    }
+
+    // Base case: no aliasing.
+    let json = config!("val.with_fields.str": "what");
+    let config: ConfigWithNestedEnum = testing::Tester::default()
+        .coerce_serde_enums()
+        .test(json)
+        .unwrap();
+    assert_matches!(
+        &config.val,
+        EnumConfig::WithFields { string: Some(s), .. } if s == "what"
+    );
+
+    let json = config!("value.with_fields.string": "what");
+    let config: ConfigWithNestedEnum = testing::Tester::default()
+        .coerce_serde_enums()
+        .test(json)
+        .unwrap();
+    assert_matches!(
+        &config.val,
+        EnumConfig::WithFields { string: Some(s), .. } if s == "what"
+    );
+
+    // Some more aliases for variant and the enclosed field.
+    let json = config!("value.fields.str": "what");
+    let config: ConfigWithNestedEnum = testing::Tester::default()
+        .coerce_serde_enums()
+        .test(json)
+        .unwrap();
+    assert_matches!(
+        &config.val,
+        EnumConfig::WithFields { string: Some(s), .. } if s == "what"
+    );
+}

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -16,7 +16,8 @@ use crate::{
         extract_env_var_name, extract_json_name, test_config_roundtrip, test_deserialize,
         AliasedConfig, ComposedConfig, CompoundConfig, ConfigWithComplexTypes, ConfigWithFallbacks,
         ConfigWithNestedValidations, ConfigWithNesting, ConfigWithValidations, DefaultingConfig,
-        EnumConfig, KvTestConfig, NestedConfig, SecretConfig, SimpleEnum, ValueCoercingConfig,
+        EnumConfig, KvTestConfig, NestedConfig, RenamedEnumConfig, SecretConfig, SimpleEnum,
+        ValueCoercingConfig,
     },
     value::StrValue,
     ByteSize, DescribeConfig, SerializerOptions,
@@ -1621,4 +1622,21 @@ fn coercing_serde_enum_negative_cases() {
         .unwrap_err();
     assert_eq!(err.len(), 1);
     assert_eq!(err.first().path(), "type");
+}
+
+#[test]
+fn coercing_nested_enum_config() {
+    let json = config!("next.nested.renamed": "second");
+    let config: RenamedEnumConfig = testing::Tester::default()
+        .coerce_serde_enums()
+        .test(json)
+        .unwrap();
+    assert_eq!(
+        config,
+        RenamedEnumConfig::V3(EnumConfig::Nested(NestedConfig {
+            simple_enum: SimpleEnum::Second,
+            other_int: 42,
+            map: HashMap::new(),
+        }))
+    );
 }

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -212,6 +212,12 @@ impl<C: DeserializeConfig> Tester<C> {
         self
     }
 
+    /// Enables coercion of serde-style enums.
+    pub fn coerce_serde_enums(&mut self) -> &mut Self {
+        self.de_options.coerce_serde_enums = true;
+        self
+    }
+
     /// Sets mock environment variables that will be recognized by [`Environment`](crate::Environment)
     /// and [`Env`](crate::fallback::Env) fallbacks.
     ///
@@ -233,9 +239,9 @@ impl<C: DeserializeConfig> Tester<C> {
     /// See [`test()`] for the examples of usage.
     #[allow(clippy::missing_panics_doc)] // can only panic if the config is recursively defined, which is impossible
     pub fn test(&self, sample: impl ConfigSource) -> Result<C, ParseErrors> {
-        let mut repo = ConfigRepository::new(&self.schema).with(sample);
+        let mut repo = ConfigRepository::new(&self.schema);
         *repo.deserializer_options() = self.de_options.clone();
-        repo.single::<C>().unwrap().parse()
+        repo.with(sample).single::<C>().unwrap().parse()
     }
 
     /// Tests config deserialization ensuring that *all* declared config params are covered.
@@ -253,8 +259,9 @@ impl<C: DeserializeConfig> Tester<C> {
     ///
     /// See [`test_complete()`] for the examples of usage.
     pub fn test_complete(&self, sample: impl ConfigSource) -> Result<C, ParseErrors> {
-        let mut repo = ConfigRepository::new(&self.schema).with(sample);
+        let mut repo = ConfigRepository::new(&self.schema);
         *repo.deserializer_options() = self.de_options.clone();
+        let repo = repo.with(sample);
 
         let metadata = &C::DESCRIPTION;
         let mut missing_params = HashMap::new();

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -110,7 +110,7 @@ pub(crate) enum EnumConfig {
     Nested(NestedConfig),
     #[config(alias = "Fields", alias = "With")]
     WithFields {
-        #[config(default)]
+        #[config(default, alias = "str")]
         string: Option<String>,
         #[config(default_t = true)]
         flag: bool,

--- a/crates/smart-config/src/testonly.rs
+++ b/crates/smart-config/src/testonly.rs
@@ -131,6 +131,8 @@ pub(crate) enum RenamedEnumConfig {
     V2 {
         str: String,
     },
+    #[config(alias = "next")]
+    V3(EnumConfig),
 }
 
 #[derive(Debug, PartialEq, DescribeConfig, DeserializeConfig, ExampleConfig)]

--- a/crates/smart-config/src/utils.rs
+++ b/crates/smart-config/src/utils.rs
@@ -167,6 +167,10 @@ impl<'a> EnumVariant<'a> {
         dest
     }
 
+    pub(crate) fn to_snake_case(&self) -> String {
+        self.transform(TargetCase::SnakeCase)
+    }
+
     // This logic can be optimized, e.g. by detecting the case in `variants`.
     pub(crate) fn try_match(&self, variants: &[&'static str]) -> Option<&'static str> {
         // First, search a complete match to provide a shortcut for the common case.


### PR DESCRIPTION
# What ❔

Allows coercing serde-style enums (objects with a single field corresponding to the variant) to the native internally tagged representation.

## Why ❔

Serde-style enums are currently used in file-based configs in Era.

Unfortunately, in one case (`da_client.eigen.points_source_url`), even this coercion is not enough. Otherwise, it seems to work (tested via `zksync_config` unit tests and configs for all envs).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.