### PR TITLE
fix: Support optional values in `NamedEntries`; fix object nesting

### DIFF
--- a/crates/smart-config/src/de/mod.rs
+++ b/crates/smart-config/src/de/mod.rs
@@ -58,7 +58,7 @@ pub use self::{
     deserializer::DeserializerOptions,
     macros::Serde,
     param::{DeserializeParam, Optional, OrString, Qualified, Serde, WellKnown, WithDefault},
-    repeated::{Delimited, Entries, NamedEntries, Repeated},
+    repeated::{Delimited, Entries, NamedEntries, Repeated, ToEntries},
     secret::{FromSecretString, Secret},
     units::WithUnit,
 };

--- a/crates/smart-config/src/de/tests.rs
+++ b/crates/smart-config/src/de/tests.rs
@@ -595,8 +595,13 @@ fn errors_parsing_named_entries() {
     assert_eq!(err.len(), 1);
     let err = err.first();
     assert_eq!(err.path(), "entry_map.0");
+    let origin = err.origin().to_string();
+    assert!(
+        origin.ends_with("-> path 'entry_map.0' -> missing entry value"),
+        "{origin}"
+    );
     let inner = err.inner().to_string();
-    assert!(inner.contains("missing field `timeout`"), "{inner}");
+    assert!(inner.contains("invalid type: null"), "{inner}");
 
     let json = config!("entry_map": serde_json::json!([{ "timeout": "30s" }]));
     let err = test_deserialize::<ComposedConfig>(json.inner()).unwrap_err();

--- a/crates/smart-config/src/metadata/mod.rs
+++ b/crates/smart-config/src/metadata/mod.rs
@@ -1,6 +1,6 @@
 //! Configuration metadata.
 
-use std::{any, borrow::Cow, fmt, ops, time::Duration};
+use std::{any, borrow::Cow, fmt, iter, ops, time::Duration};
 
 use self::_private::{BoxedDeserializer, BoxedVisitor};
 use crate::{
@@ -72,6 +72,17 @@ pub struct ConfigMetadata {
     pub visitor: BoxedVisitor,
     #[doc(hidden)] // implementation detail
     pub validations: &'static [&'static dyn Validate<dyn any::Any>],
+}
+
+impl ConfigMetadata {
+    pub(crate) fn all_child_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        let param_names = self.params.iter().flat_map(ParamMetadata::all_names);
+        let config_names = self
+            .nested_configs
+            .iter()
+            .flat_map(NestedConfigMetadata::all_names);
+        param_names.chain(config_names)
+    }
 }
 
 /// Information about a config tag.
@@ -150,6 +161,14 @@ impl ParamMetadata {
         self.deserializer.describe(&mut description);
         description.rust_type = self.rust_type.name_in_code;
         description
+    }
+
+    fn all_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        iter::once(self.name).chain(
+            self.aliases
+                .iter()
+                .filter_map(|&(alias, _)| (!alias.starts_with('.')).then_some(alias)),
+        )
     }
 }
 
@@ -451,6 +470,16 @@ pub struct NestedConfigMetadata {
     pub tag_variant: Option<&'static ConfigVariant>,
     /// Config metadata.
     pub meta: &'static ConfigMetadata,
+}
+
+impl NestedConfigMetadata {
+    fn all_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        let name = (!self.name.is_empty()).then_some(self.name);
+        name.into_iter()
+            .chain(self.aliases.iter().filter_map(|&(alias, _)| {
+                (!alias.is_empty() && !alias.starts_with('.')).then_some(alias)
+            }))
+    }
 }
 
 /// Unit of time measurement.

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -9,6 +9,7 @@ use secrecy::ExposeSecret;
 
 use super::*;
 use crate::{
+    de,
     metadata::{AliasOptions, SizeUnit},
     testing,
     testing::MockEnvGuard,
@@ -1830,4 +1831,27 @@ fn resolving_path_aliases_for_configs() {
     let repo = ConfigRepository::new(&schema).with(env);
     let config: ConfigWithPathAlias = repo.single().unwrap().parse().unwrap();
     assert_eq!(config.nested.simple_enum, SimpleEnum::Second);
+}
+
+#[test]
+fn parsing_named_entries_with_optional_values() {
+    #[derive(Debug, DescribeConfig, DeserializeConfig)]
+    #[config(crate = crate)]
+    struct TestConfig {
+        #[config(with = de::Entries::WELL_KNOWN.named("method", "value"))]
+        overrides: HashMap<String, Option<usize>>,
+    }
+
+    let json = config!(
+        "overrides": serde_json::json!([
+            { "method": "call" },
+            { "method": "submit", "value": null },
+            { "method": "revert", "value": 3 },
+        ]),
+    );
+    let config: TestConfig = testing::test_complete(json).unwrap();
+    assert_eq!(config.overrides.len(), 3);
+    assert_eq!(config.overrides["call"], None);
+    assert_eq!(config.overrides["submit"], None);
+    assert_eq!(config.overrides["revert"], Some(3));
 }


### PR DESCRIPTION
# What ❔

- Supports optional values in `NamedEntries`.
- Fixes object nesting some more when embedded params involved.

## Why ❔

Necessary for Era (`max_response_body_size_overrides` param in the API config).

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.