### PR TITLE
refactor: Use path aliases for fields in enum configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,7 @@ version = "0.2.0-pre"
 dependencies = [
  "anstream",
  "anstyle",
+ "anyhow",
  "clap",
  "doc-comment",
  "primitive-types",

--- a/crates/smart-config-commands/Cargo.toml
+++ b/crates/smart-config-commands/Cargo.toml
@@ -20,6 +20,7 @@ smart-config.workspace = true
 [dev-dependencies]
 smart-config = { workspace = true, features = ["primitive-types"] }
 
+anyhow.workspace = true
 clap = { workspace = true, features = ["derive"] }
 doc-comment.workspace = true
 primitive-types.workspace = true

--- a/crates/smart-config-commands/src/debug.rs
+++ b/crates/smart-config-commands/src/debug.rs
@@ -232,9 +232,14 @@ impl<W: RawStream + AsLockedWrite> Printer<W> {
                 if let Some(errors) = errors.by_param.get(&param_id) {
                     if !param_written {
                         let field_name = param.rust_field_name;
+                        let rust_variant = if let Some(variant) = param.tag_variant {
+                            format!("::{}", variant.rust_name)
+                        } else {
+                            String::new()
+                        };
                         writeln!(
                             writer,
-                            "{canonical_path} {RUST}[Rust: {config_name}.{field_name}]{RUST:#}"
+                            "{canonical_path} {RUST}[Rust: {config_name}{rust_variant}.{field_name}]{RUST:#}"
                         )?;
                     }
                     write_de_errors(&mut writer, errors)?;
@@ -297,9 +302,15 @@ fn write_param(
     } else {
         INACTIVE
     };
+    let rust_variant = if let Some(variant) = param_ref.param.tag_variant {
+        format!("::{}", variant.rust_name)
+    } else {
+        String::new()
+    };
+
     write!(
         writer,
-        "{activity_style}{path}{activity_style:#} {RUST}[Rust: {}.{}]{RUST:#}",
+        "{activity_style}{path}{activity_style:#} {RUST}[Rust: {}{rust_variant}.{}]{RUST:#}",
         param_ref.config.metadata().ty.name_in_code(),
         param_ref.param.rust_field_name
     )?;

--- a/crates/smart-config-commands/src/lib.rs
+++ b/crates/smart-config-commands/src/lib.rs
@@ -48,6 +48,7 @@
 #![warn(missing_docs)]
 
 use std::{
+    collections::HashSet,
     io,
     io::{StderrLock, StdoutLock},
 };
@@ -129,7 +130,11 @@ impl ParamRef<'_> {
 
     /// Iterates over all paths to the param.
     pub fn all_paths(&self) -> impl Iterator<Item = (String, AliasOptions)> + '_ {
-        self.config.all_paths_for_param(self.param)
+        // Deduplicate paths so that duplicates aren't displayed in UI; `all_paths_for_param()` doesn't do this internally.
+        let mut known_paths = HashSet::new();
+        self.config
+            .all_paths_for_param(self.param)
+            .filter(move |(name, _)| known_paths.insert(name.clone()))
     }
 }
 

--- a/crates/smart-config/src/de/deserializer.rs
+++ b/crates/smart-config/src/de/deserializer.rs
@@ -22,52 +22,6 @@ use crate::{
 pub struct DeserializerOptions {
     /// Enables coercion of variant names between cases, e.g. from `SHOUTING_CASE` to `shouting_case`.
     pub coerce_variant_names: bool,
-    /// Enables coercion of serde-like enums to canonical internally tagged representation.
-    ///
-    /// A serde-style enum is encoded as an object with a single field named after one of variants
-    /// (incl. aliases) converted to `snake_case`. Coercing is not performed if the tag param is present,
-    /// if there are multiple variant-named fields, or if the variant field value is not an object.
-    /// As a result of coercing, a tag param is added with the appropriate value, and fields in the variant field
-    /// are copied one level upper; they have lower priority than existing fields and never overwrite them.
-    ///
-    /// # Examples
-    ///
-    /// For example, consider an enum config
-    ///
-    /// ```
-    /// use smart_config::{DescribeConfig, DeserializeConfig};
-    /// #[derive(Debug, DescribeConfig, DeserializeConfig)]
-    /// #[config(tag = "type")]
-    /// pub enum TestConfig {
-    ///     String { str: String },
-    ///     IntValue { int: u64 },
-    /// }
-    /// ```
-    ///
-    /// ...mounted at `test`. Then, example serde-style serialization are:
-    ///
-    /// ```yaml
-    /// test:
-    ///   string:
-    ///     str: 'what?'
-    /// ---
-    /// test:
-    ///   int_value:
-    ///     int: 42
-    /// ```
-    ///
-    /// After coercion, these will be transformed to
-    ///
-    /// ```yaml
-    /// test:
-    ///   type: String
-    ///   str: 'what?'
-    /// ---
-    /// test:
-    ///   type: IntValue
-    ///   int: 42
-    /// ```
-    pub coerce_serde_enums: bool,
 }
 
 impl WithOrigin {

--- a/crates/smart-config/src/schema/mod.rs
+++ b/crates/smart-config/src/schema/mod.rs
@@ -237,7 +237,7 @@ impl ConfigSchema {
     /// to nested enum configs as well.
     ///
     /// For example, if a config param named `param` corresponds to the tag `SomeTag`, then alias `.some_tag.param`
-    /// (snake_cased tag + param name) will be added for the param. Tag aliases and param aliases will result
+    /// (`snake_cased` tag + param name) will be added for the param. Tag aliases and param aliases will result
     /// in additional path aliases, as expected. For example, if `param` has alias `alias` and the tag has alias `AliasTag`,
     /// then the param will have `.alias_tag.param`, `.alias_tag.alias` and `.some_tag.alias` aliases.
     pub fn coerce_serde_enums(&mut self, coerce: bool) -> &mut Self {

--- a/crates/smart-config/src/schema/mod.rs
+++ b/crates/smart-config/src/schema/mod.rs
@@ -232,7 +232,14 @@ impl ConfigSchema {
         this
     }
 
-    /// Switches coercing for serde-like enums. This will add path aliases for all params in enum configs.
+    /// Switches coercing for serde-like enums. Coercion will add path aliases for all tagged params in enum configs
+    /// added to the schema afterward (or until `coerce_serde_enums(false)` is called). Coercion will apply
+    /// to nested enum configs as well.
+    ///
+    /// For example, if a config param named `param` corresponds to the tag `SomeTag`, then alias `.some_tag.param`
+    /// (snake_cased tag + param name) will be added for the param. Tag aliases and param aliases will result
+    /// in additional path aliases, as expected. For example, if `param` has alias `alias` and the tag has alias `AliasTag`,
+    /// then the param will have `.alias_tag.param`, `.alias_tag.alias` and `.some_tag.alias` aliases.
     pub fn coerce_serde_enums(&mut self, coerce: bool) -> &mut Self {
         self.coerce_serde_enums = coerce;
         self

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -708,7 +708,7 @@ impl WithOrigin {
                 tracing::debug!(
                     variant = variant.name,
                     origin = %variant_content.origin,
-                    "copying variant contents"
+                    "adding detected tag variant"
                 );
                 let origin = ValueOrigin::Synthetic {
                     source: variant_content.origin.clone(),

--- a/crates/smart-config/src/source/mod.rs
+++ b/crates/smart-config/src/source/mod.rs
@@ -10,7 +10,7 @@ pub use self::{env::Environment, json::Json, yaml::Yaml};
 use crate::{
     de::{DeserializeContext, DeserializerOptions},
     fallback::Fallbacks,
-    metadata::{BasicTypes, ConfigTag, TypeSuffixes},
+    metadata::{BasicTypes, ConfigTag, ConfigVariant, TypeSuffixes},
     schema::{ConfigData, ConfigRef, ConfigSchema},
     utils::{merge_json, EnumVariant, JsonObject},
     value::{Map, Pointer, Value, ValueOrigin, WithOrigin},
@@ -293,11 +293,8 @@ impl<'a> ConfigRepository<'a> {
             }
         };
 
-        let param_count = source_value.preprocess_source(
-            self.schema,
-            &self.prefixes_for_canonical_configs,
-            &self.de_options,
-        );
+        let param_count =
+            source_value.preprocess_source(self.schema, &self.prefixes_for_canonical_configs);
         tracing::debug!(param_count, "Inserted source into config repo");
         self.merged
             .guided_merge(source_value, self.schema, Pointer(""));
@@ -493,13 +490,10 @@ impl WithOrigin {
         &mut self,
         schema: &ConfigSchema,
         prefixes_for_canonical_configs: &HashSet<Pointer<'_>>,
-        options: &DeserializerOptions,
     ) -> usize {
         self.copy_aliased_values(schema);
         self.mark_secrets(schema);
-        if options.coerce_serde_enums {
-            self.convert_serde_enums(schema);
-        }
+        self.convert_serde_enums(schema);
         self.nest_object_params_and_sub_configs(schema);
         self.nest_array_params(schema);
         self.collect_garbage(schema, prefixes_for_canonical_configs, Pointer(""))
@@ -679,7 +673,6 @@ impl WithOrigin {
 
     #[tracing::instrument(level = "debug", skip_all)]
     fn convert_serde_enums(&mut self, schema: &ConfigSchema) {
-        // We need ordered iteration here (parent configs before children) to avoid skipping nested enum configs.
         for config_data in schema.iter() {
             let config_meta = config_data.metadata();
             let prefix = Pointer(config_data.prefix());
@@ -687,6 +680,10 @@ impl WithOrigin {
             let Some(tag) = &config_meta.tag else {
                 continue; // Not an enum config, nothing to do.
             };
+            if !config_data.data.coerce_serde_enums {
+                continue;
+            }
+
             let canonical_map = self.get(prefix).and_then(|val| val.inner.as_object());
             let alias_maps = config_data
                 .aliases()
@@ -705,30 +702,38 @@ impl WithOrigin {
             )
             .entered();
 
-            if let Some(new_values) = Self::convert_serde_enum(canonical_map, alias_maps, tag) {
+            if let Some((variant, variant_content)) =
+                Self::detect_serde_enum_variant(canonical_map, alias_maps, tag)
+            {
+                tracing::debug!(
+                    variant = variant.name,
+                    origin = %variant_content.origin,
+                    "copying variant contents"
+                );
+                let origin = ValueOrigin::Synthetic {
+                    source: variant_content.origin.clone(),
+                    transform: "coercing serde enum".to_owned(),
+                };
+
                 let canonical_map = self.ensure_object(prefix, |_| {
                     Arc::new(ValueOrigin::Synthetic {
                         source: Arc::default(),
                         transform: "enum coercion".to_string(),
                     })
                 });
-                canonical_map.extend(new_values);
-
-                // Run local de-aliasing for the config again.
-                let (new_values, _) = self.copy_aliases_for_config(config_data.data);
-                // `unwrap()`s are safe: we've ensured the canonical map existence above.
-                let canonical_map = self.get_mut(prefix).unwrap().inner.as_object_mut().unwrap();
-                canonical_map.extend(new_values);
+                canonical_map.insert(
+                    tag.param.name.to_owned(),
+                    WithOrigin::new(variant.name.to_owned().into(), Arc::new(origin)),
+                );
             }
         }
     }
 
-    #[must_use = "returned `Map` should be merged"]
-    fn convert_serde_enum<'a>(
+    fn detect_serde_enum_variant<'a>(
         canonical_map: Option<&'a Map>,
         alias_maps: impl Iterator<Item = &'a Map>,
-        tag: &ConfigTag,
-    ) -> Option<Map> {
+        tag: &'static ConfigTag,
+    ) -> Option<(&'static ConfigVariant, &'a Self)> {
         let all_variant_names = tag.variants.iter().flat_map(|variant| {
             iter::once(variant.name)
                 .chain(variant.aliases.iter().copied())
@@ -766,38 +771,7 @@ impl WithOrigin {
             );
             return None;
         }
-
-        tracing::debug!(
-            field = field_name,
-            variant = variant.name,
-            "copying variant contents"
-        );
-        let origin = ValueOrigin::Synthetic {
-            source: variant_content.origin.clone(),
-            transform: "coercing serde enum".to_owned(),
-        };
-        let Value::Object(variant_content) = variant_content.inner.clone() else {
-            unreachable!(); // checked above
-        };
-
-        let mut new_values = Map::new();
-        new_values.insert(
-            tag.param.name.to_owned(),
-            WithOrigin::new(variant.name.to_owned().into(), Arc::new(origin)),
-        );
-
-        for (key, value) in variant_content {
-            #[allow(clippy::map_entry)] // False positive: `key` would need to be cloned
-            if canonical_map.is_some_and(|map| map.contains_key(&key)) {
-                tracing::info!(
-                    field = key,
-                    "config already contains field, not overwriting it"
-                );
-            } else {
-                new_values.insert(key, value);
-            }
-        }
-        (!new_values.is_empty()).then_some(new_values)
+        Some((variant, variant_content))
     }
 
     /// Removes all values that do not correspond to canonical params or their ancestors.

--- a/crates/smart-config/src/source/tests.rs
+++ b/crates/smart-config/src/source/tests.rs
@@ -1505,13 +1505,8 @@ fn config_canonicalization_with_nesting() {
 
 #[test]
 fn coercing_serde_enum() {
-    let mut schema = ConfigSchema::default();
-    schema
-        .coerce_serde_enums(true)
-        .insert(&EnumConfig::DESCRIPTION, "")
-        .unwrap();
-    let mut tester = testing::Tester::new(schema);
-    let tester = tester.for_config::<EnumConfig>();
+    let mut tester = testing::Tester::default();
+    let tester = tester.coerce_serde_enums().insert::<EnumConfig>("");
 
     let json = config!("fields.string": "!", "fields.flag": false, "fields.set": [123]);
     let config = tester.test(json).unwrap();
@@ -1549,13 +1544,8 @@ fn coercing_serde_enum() {
 
 #[test]
 fn coercing_serde_enum_with_aliased_field() {
-    let mut schema = ConfigSchema::default();
-    schema
-        .coerce_serde_enums(true)
-        .insert(&EnumConfig::DESCRIPTION, "")
-        .unwrap();
-    let mut tester = testing::Tester::new(schema);
-    let tester = tester.for_config::<EnumConfig>();
+    let mut tester = testing::Tester::default();
+    let tester = tester.coerce_serde_enums().insert::<EnumConfig>("");
 
     let json = config!("fields.str": "?", "fields.flag": false);
     let config: EnumConfig = tester.test(json).unwrap();
@@ -1598,13 +1588,8 @@ fn origins_for_coerced_serde_enum() {
 
 #[test]
 fn coercing_serde_enum_negative_cases() {
-    let mut schema = ConfigSchema::default();
-    schema
-        .coerce_serde_enums(true)
-        .insert(&EnumConfig::DESCRIPTION, "")
-        .unwrap();
-    let mut tester = testing::Tester::new(schema);
-    let tester = tester.for_config::<EnumConfig>();
+    let mut tester = testing::Tester::default();
+    let tester = tester.coerce_serde_enums().insert::<EnumConfig>("");
 
     // Multiple variant fields present
     let json = config!("fields.string": "!", "nested.renamed": "first");
@@ -1627,13 +1612,8 @@ fn coercing_serde_enum_negative_cases() {
 
 #[test]
 fn coercing_nested_enum_config() {
-    let mut schema = ConfigSchema::default();
-    schema
-        .coerce_serde_enums(true)
-        .insert(&RenamedEnumConfig::DESCRIPTION, "")
-        .unwrap();
-    let mut tester = testing::Tester::new(schema);
-    let tester = tester.for_config::<RenamedEnumConfig>();
+    let mut tester = testing::Tester::default();
+    let tester = tester.coerce_serde_enums().insert::<RenamedEnumConfig>("");
 
     let json = config!("next.nested.renamed": "second");
     let config = tester.test(json).unwrap();
@@ -1656,13 +1636,10 @@ fn coercing_aliased_enum_config() {
         val: EnumConfig,
     }
 
-    let mut schema = ConfigSchema::default();
-    schema
-        .coerce_serde_enums(true)
-        .insert(&ConfigWithNestedEnum::DESCRIPTION, "")
-        .unwrap();
-    let mut tester = testing::Tester::new(schema);
-    let tester = tester.for_config::<ConfigWithNestedEnum>();
+    let mut tester = testing::Tester::default();
+    let tester = tester
+        .coerce_serde_enums()
+        .insert::<ConfigWithNestedEnum>("");
 
     // Base case: no aliasing.
     let json = config!("val.with_fields.str": "what");
@@ -1941,13 +1918,8 @@ fn coercing_enum_with_suffixes() {
         },
     }
 
-    let mut schema = ConfigSchema::default();
-    schema
-        .coerce_serde_enums(true)
-        .insert(&TestConfig::DESCRIPTION, "test")
-        .unwrap();
-    let mut tester = testing::Tester::new(schema);
-    let tester = tester.for_config::<TestConfig>();
+    let mut tester = testing::Tester::default();
+    let tester = tester.coerce_serde_enums().insert::<TestConfig>("test");
 
     let env = Environment::from_iter("", [("TEST_V1_TIMEOUT_MS", "100")]);
     let config = tester.test_complete(env).unwrap();

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -423,12 +423,6 @@ impl<C> Tester<'_, C> {
         self
     }
 
-    /// Enables coercion of serde-style enums.
-    pub fn coerce_serde_enums(&mut self) -> &mut Self {
-        self.data.as_mut().de_options.coerce_serde_enums = true;
-        self
-    }
-
     /// Sets mock environment variables that will be recognized by [`Environment`](crate::Environment)
     /// and [`Env`](crate::fallback::Env) fallbacks.
     ///

--- a/crates/smart-config/src/testing.rs
+++ b/crates/smart-config/src/testing.rs
@@ -388,6 +388,19 @@ impl<C: DeserializeConfig + VisitConfig> Default for Tester<'static, C> {
     }
 }
 
+impl Default for Tester<'static, ()> {
+    fn default() -> Self {
+        Self {
+            data: TesterDataGoat::Owned(TesterData {
+                de_options: DeserializerOptions::default(),
+                schema: ConfigSchema::default(),
+                env_guard: MockEnvGuard::default(),
+            }),
+            _config: PhantomData,
+        }
+    }
+}
+
 impl Tester<'_, ()> {
     /// Creates a tester with the specified schema.
     pub fn new(schema: ConfigSchema) -> Self {
@@ -414,12 +427,39 @@ impl Tester<'_, ()> {
             _config: PhantomData,
         }
     }
+
+    /// Similar to [`Self::for_config()`], but inserts the specified config into the schema rather
+    /// than expecting it to be present.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the config cannot be inserted into the schema.
+    pub fn insert<C: DeserializeConfig + VisitConfig>(
+        &mut self,
+        prefix: &'static str,
+    ) -> Tester<'_, C> {
+        self.data
+            .as_mut()
+            .schema
+            .insert(&C::DESCRIPTION, prefix)
+            .expect("failed inserting config into schema");
+        Tester {
+            data: TesterDataGoat::Borrowed(self.data.as_mut()),
+            _config: PhantomData,
+        }
+    }
 }
 
 impl<C> Tester<'_, C> {
     /// Enables coercion of enum variant names.
     pub fn coerce_variant_names(&mut self) -> &mut Self {
         self.data.as_mut().de_options.coerce_variant_names = true;
+        self
+    }
+
+    /// Enables coercion of serde-style enums.
+    pub fn coerce_serde_enums(&mut self) -> &mut Self {
+        self.data.as_mut().schema.coerce_serde_enums(true);
         self
     }
 

--- a/crates/smart-config/src/value.rs
+++ b/crates/smart-config/src/value.rs
@@ -272,13 +272,6 @@ impl Value {
             _ => None,
         }
     }
-
-    pub(crate) fn as_object_mut(&mut self) -> Option<&mut Map> {
-        match self {
-            Self::Object(map) => Some(map),
-            _ => None,
-        }
-    }
 }
 
 /// JSON object.


### PR DESCRIPTION
# What ❔

Automatically derives path aliases for enum configs as an opt-in when creating a config schema. 

## Why ❔

This makes handing serde-like enums much less "magical". E.g., these aliases are documented in the help CLI command, participate in config source pre-processing (e.g., converting env variables) etc.

## Checklist


- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted and linted using `cargo fmt` and `cargo clippy`.