### PR TITLE
ci: Downgrade `zerocopy`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   SCCACHE_GHA_ENABLED: "true"
   # Minimum supported Rust version.
   msrv: 1.88.0
-  # Nightly Rust necessary for building docs.
+  # Nightly Rust necessary for building docs. Also used to check compatibility with the ZKsync OS codebase.
   nightly: nightly-2025-05-23
 
 jobs:
@@ -71,11 +71,10 @@ jobs:
       - name: Check CLI snapshots can be generated
         run: ./crates/smart-config-commands/examples/make-snapshots.sh
 
-  document:
+  build-nightly:
     needs:
       - build
       - build-msrv
-    if: github.event_name == 'push' && github.ref_type == 'branch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -90,7 +89,11 @@ jobs:
       - name: Install sccache
         uses: mozilla-actions/sccache-action@v0.0.9
 
+      - name: Build libraries
+        run: cargo build --workspace --lib --all-features
+
       - name: Build docs
+        if: github.event_name == 'push' && github.ref_type == 'branch'
         run: |
           cargo clean --doc && \
           cargo rustdoc -p smart-config-derive --all-features -- -Z unstable-options --enable-index-page && \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,15 +93,15 @@ jobs:
         run: cargo build --workspace --lib --all-features
 
       - name: Build docs
-        if: github.event_name == 'push' && github.ref_type == 'branch'
         run: |
           cargo clean --doc && \
-          cargo rustdoc -p smart-config-derive --all-features -- -Z unstable-options --enable-index-page && \
-          cargo rustdoc -p smart-config --all-features -- -Z unstable-options --enable-index-page --cfg docsrs && \
-          cargo rustdoc -p smart-config-commands --all-features -- -Z unstable-options --enable-index-page
+          cargo rustdoc -p smart-config-derive --all-features -- -D warnings -Z unstable-options --enable-index-page && \
+          cargo rustdoc -p smart-config --all-features -- -D warnings -Z unstable-options --enable-index-page --cfg docsrs && \
+          cargo rustdoc -p smart-config-commands --all-features -- -D warnings -Z unstable-options --enable-index-page
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
+        if: github.event_name == 'push' && github.ref_type == 'branch'
         with:
           branch: gh-pages
           folder: target/doc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,18 +2345,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "43fa6694ed34d6e57407afbccdeecfa268c470a7d2a5b0cf49ce9fcc345afb90"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "c640b22cd9817fae95be82f0d2f90b11f7605f6c319d16705c459b27ac2cbc26"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
# What ❔

- Downgrades `zerocopy` dependency to 0.8.28. Newer versions fail to compile on x86_64 with the nightly Rust version used in the ZKsync OS server codebase (`nightly-2025-05-23`), caused by overly permissive Rust version checks in its build script (this nightly version is 1.89.0, but it doesn't have all features the *released* 1.89.0 has).
- Compiles the workspace with the nightly Rust version in CI.

## Why ❔

- Updating `zerocopy` has broken CI (specifically, document generation).
- Checking compatibility with the Rust version used in the ZKsync OS server codebase has obvious benefits.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).