### PR TITLE
ci(release-please): update version of the release please job and remove cargo registry token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,11 +20,10 @@ on:
 jobs:
   # Prepare the release PR with changelog updates and create github releases
   release-please:
-    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@v1
+    uses: matter-labs/zksync-ci-common/.github/workflows/release-please.yaml@c3b31c6f11bada204069c8b4621044e4c1cbc1df
     secrets:
       slack_webhook: ${{ secrets.SLACK_WEBHOOK_RELEASES }}
       gh_token: ${{ secrets.RELEASE_TOKEN }}
-      cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}
     with:
       config: '.github/release-please/config.json'     # Specify the path to the configuration file
       manifest: '.github/release-please/manifest.json' # Specify the path to the manifest file


### PR DESCRIPTION
## What ❔

- update versions of reusable workflows used to publish crates to crates.io. New version of those workflows use trusted publishing instead of static API tokens
- due to the limitation of trusted publishing, new crates in crates.io will have to be initially created by DevOps:
> Your crate must already be published to crates.io (initial publish requires an API token)

## Why ❔

- trusted publishing replaces long-lived crates.io API tokens with short-lived, OIDC-issued credentials scoped to a specific repo and workflow. This removes a standing secret that could leak and would need manual rotation, and follows crates.io's recommended publishing setup.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and `cargo clippy`.

---
reusable CI changes: https://github.com/matter-labs/zksync-ci-common/pull/51/changes